### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 &ensp;|&ensp;
 [Blog](https://www.speechly.com/blog/?utm_source=github&utm_medium=browser-client&utm_campaign=header)
 &ensp;|&ensp;
-[Podcast](https://anchor.fm/collin-borns/episodes/The-Speechly-Podcast---Introduction-e15htlq)
+[Podcast](https://anchor.fm/the-speechly-podcast)
 
 ---
 </div>


### PR DESCRIPTION
### What

This fixes podcast link url so that it sends the user to the podcast root instead of a single episode

### Why

It previously sent the user to the intro episode

