### PR TITLE
Browser UI/embedded doc update and 5.0.1 publish for unpkg

### DIFF
--- a/common/changes/@speechly/browser-ui/browser-ui-embedded-doc-update_2021-11-15-15-22.json
+++ b/common/changes/@speechly/browser-ui/browser-ui-embedded-doc-update_2021-11-15-15-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "Changed url references to unpkg.com. rushx start will now start dev server in watch mode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/common/changes/@speechly/browser-ui/browser-ui-embedded-doc-update_2021-11-15-15-24.json
+++ b/common/changes/@speechly/browser-ui/browser-ui-embedded-doc-update_2021-11-15-15-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "5.0.1 published with production build.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/libraries/browser-ui/package.json
+++ b/libraries/browser-ui/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "build": "rollup -c --silent",
     "build:watch": "rollup -c --silent",
-    "dev": "rollup -c -w",
-    "start": "sirv core",
+    "start": "rollup -c -w",
     "validate": "svelte-check"
   },
   "devDependencies": {

--- a/libraries/browser-ui/package.json
+++ b/libraries/browser-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/browser-ui",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "scripts": {
     "build": "rollup -c --silent",
     "build:watch": "rollup -c --silent",

--- a/libraries/browser-ui/src/assets/extras.html
+++ b/libraries/browser-ui/src/assets/extras.html
@@ -35,8 +35,8 @@
     <h2>Quick installation from CDN</h2>
       Include the resources in your <code>&lt;head&gt;</code> block:
 <xmp><head>
-  <script type="text/javascript" src="https://speechly.github.io/browser-ui/dev/transcript-drawer.js"></script>
-  <script type="text/javascript" src="https://speechly.github.io/browser-ui/dev/intro-popup.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@speechly/browser-ui/core/transcript-drawer.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@speechly/browser-ui/core/intro-popup.js"></script>
 </head>
 </xmp>
     

--- a/libraries/browser-ui/src/assets/index.html
+++ b/libraries/browser-ui/src/assets/index.html
@@ -33,9 +33,9 @@
     <h2>Quick installation from CDN</h2>
       Include the resources in your <code>&lt;head&gt;</code> block:
 <xmp><head>
-  <script type="text/javascript" src="https://speechly.github.io/browser-ui/dev/push-to-talk-button.js"></script>
-  <script type="text/javascript" src="https://speechly.github.io/browser-ui/dev/big-transcript.js"></script>
-  <script type="text/javascript" src="https://speechly.github.io/browser-ui/dev/error-panel.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@speechly/browser-ui/core/push-to-talk-button.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@speechly/browser-ui/core/big-transcript.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@speechly/browser-ui/core/error-panel.js"></script>
 </head>
 </xmp>
     These scripts add Speechly's components to the page's custom element registry to be used in HTML markup as shown below.
@@ -95,7 +95,7 @@
         <li><code>capturekey</code> - Optional string (of length 1). Defines a keyboard hotkey that with control listening on/off. Default: undefined. Recommendation: Space (" ")</li>
         <li><code>size</code> - Optional string (CSS). Defines the button frame width and height. Default: "6rem"</li>
         <li><code>hide</code> - Optional "false" | "true". Default: "false"</li>
-        <li><code>placement</code> - Optional "bottom" turns on internal placement without <a href="https://speechly.github.io/browser-ui/dev/speechly-ui.css">PushToTalkContainer</a> CSS class</li>
+        <li><code>placement</code> - Optional "bottom" turns on internal placement without <a href="https://unpkg.com/@speechly/browser-ui/core/speechly-ui.css">PushToTalkContainer</a> CSS class</li>
         <li><code>voffset</code> - Optional CSS string. Vertical distance from viewport edge. Only effective when using placement.</li>
         <li><code>intro</code> - Optional string containing a short usage introduction. Displayed when the component is first displayed. Default: "Push to talk". Set to "" to disable.</li>
         <li><code>hint</code> - Optional string containing a short usage hint. Displayed on a short tap. Default: "Push to talk". Set to "" to disable.</li>
@@ -143,7 +143,7 @@
     <component-api id="big-transcript-api">
       <h3>Attributes</h3>
       <ul>
-        <li><code>placement</code> - Optional "top" turns on internal placement without <a href="https://speechly.github.io/browser-ui/dev/speechly-ui.css">BigTranscriptContainer</a> CSS class</li>
+        <li><code>placement</code> - Optional "top" turns on internal placement without <a href="https://unpkg.com/@speechly/browser-ui/core/speechly-ui.css">BigTranscriptContainer</a> CSS class</li>
         <li><code>hoffset</code> - Optional CSS string. Horizontal distance from viewport edge. Only effective when using placement.</li>
         <li><code>voffset</code> - Optional CSS string. Vertical distance from viewport edge. Only effective when using placement.</li>
         <li><code>fontsize</code> - Optional CSS string for text size. Default: "1.5rem"</li>
@@ -177,7 +177,7 @@
 	  Autonomous customElement that displays a stateless, holdable button with an icon and emits events on press.
     <h3>Installation</h3>
 <xmp><head>
-  <script type="text/javascript" src="https://speechly.github.io/browser-ui/dev/holdable-button.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@speechly/browser-ui/core/holdable-button.js"></script>
 </head>
 </xmp>
     


### PR DESCRIPTION
### What

Changed links to point to unpkg.com in embedded docs.

### Why

Deprecating GitHub pages CDN deployment.
