### PR TITLE
Update @speechly/demo-navigation 0.1.29 → 0.1.30

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -19,7 +19,7 @@ specifiers:
   '@rush-temp/react-voice-forms': file:./projects/react-voice-forms.tgz
   '@rush-temp/smart-home': file:./projects/smart-home.tgz
   '@rush-temp/speech-to-text': file:./projects/speech-to-text.tgz
-  '@speechly/demo-navigation': ^0.1.29
+  '@speechly/demo-navigation': ^0.1.30
   '@testing-library/jest-dom': ^4.2.4
   '@testing-library/react': ^9.3.2
   '@testing-library/user-event': ^7.1.2
@@ -91,7 +91,7 @@ dependencies:
   '@rush-temp/react-voice-forms': file:projects/react-voice-forms.tgz
   '@rush-temp/smart-home': file:projects/smart-home.tgz_ts-node@10.4.0
   '@rush-temp/speech-to-text': file:projects/speech-to-text.tgz_ts-node@10.4.0
-  '@speechly/demo-navigation': 0.1.29_react-dom@17.0.2+react@17.0.2
+  '@speechly/demo-navigation': 0.1.30_react-dom@17.0.2+react@17.0.2
   '@testing-library/jest-dom': 4.2.4
   '@testing-library/react': 9.5.0_react-dom@17.0.2+react@17.0.2
   '@testing-library/user-event': 7.2.1
@@ -4090,8 +4090,8 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@speechly/demo-navigation/0.1.29_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-iIvY5vB5KA+jtaq1WGYzpKwRPgylr+kQ7pSnCwDJfBOUox8lesHWHbRF0i7NTO70+VXvKsBM07CoJPwA9Fr1ig==}
+  /@speechly/demo-navigation/0.1.30_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-dD8sQrJhnqwiuFUjwCgITURpk9xY/XMeQj+Pu3PogKHFx7+eBNznHf8jOnXsA917WoZTf/rP8Fymn5SKQaMpKQ==}
     peerDependencies:
       react: '>=17.0.2'
       react-dom: '>=17.0.2'
@@ -17499,12 +17499,12 @@ packages:
     dev: false
 
   file:projects/ecommerce-checkout.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-x1lLImBrxu9o70YYIEYcMOUMVEP44bzAtSb6kkLC97HI5xp+jxo7fZenVrICyJxGe6iLoDIzsjQLqyaOxpM71w==, tarball: file:projects/ecommerce-checkout.tgz}
+    resolution: {integrity: sha512-11Jn2Nvjd3/qvk4X0Lr0bkyXIz2KIm1BCeA8baB/76UOSaNFiLgeT/4fP4DtyA/OqXPhLrgf44lLkyKhw9UlLg==, tarball: file:projects/ecommerce-checkout.tgz}
     id: file:projects/ecommerce-checkout.tgz
     name: '@rush-temp/ecommerce-checkout'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.29_react-dom@17.0.2+react@17.0.2
+      '@speechly/demo-navigation': 0.1.30_react-dom@17.0.2+react@17.0.2
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 7.2.1
@@ -17537,11 +17537,11 @@ packages:
     dev: false
 
   file:projects/fashion-ecommerce.tgz:
-    resolution: {integrity: sha512-4Z2cK381FHtvopVFDAXXchRdNvKfhZf+ynQBmeajwsE7uSGZQC1jzBKz7CQF5fWHl8RXER7ae7DivFYIh4S+wg==, tarball: file:projects/fashion-ecommerce.tgz}
+    resolution: {integrity: sha512-BZEnwu3Y6Aqw3H8RAKb3cOHiD/Rhq6dGQrgAeEQ0VexqpIvqua9Jt6ht/QD8Ix0dBzpcYCWCRkiwD09husVjgg==, tarball: file:projects/fashion-ecommerce.tgz}
     name: '@rush-temp/fashion-ecommerce'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.29_react-dom@17.0.2+react@17.0.2
+      '@speechly/demo-navigation': 0.1.30_react-dom@17.0.2+react@17.0.2
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 7.2.1
@@ -17585,12 +17585,12 @@ packages:
     dev: false
 
   file:projects/flight-booking.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-uGvtiaqDklVbGUx8IJgW0iqxWBNhJfqGFir5x1y5i+jw62sbUVQi1PK09zbKbgn/NfXzzLcEV/wm841L0G8Nvw==, tarball: file:projects/flight-booking.tgz}
+    resolution: {integrity: sha512-nzJRrlR4cjpx6MmYf43R/spxcwds0Sz6v3HlSr8uXTZfMmzP5BxVf69+F6tjfq2U30sijYfH70e1KxewRye93w==, tarball: file:projects/flight-booking.tgz}
     id: file:projects/flight-booking.tgz
     name: '@rush-temp/flight-booking'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.29_react-dom@17.0.2+react@17.0.2
+      '@speechly/demo-navigation': 0.1.30_react-dom@17.0.2+react@17.0.2
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 7.2.1
@@ -17772,12 +17772,12 @@ packages:
     dev: false
 
   file:projects/smart-home.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-5bQHd/1HuNkHf70dMMAejXwln3FrusPwZfSOJZxGuibMB3V8EJAJjeDzIbT1nbmVV970oeCfPRJFCMk0ZINH0g==, tarball: file:projects/smart-home.tgz}
+    resolution: {integrity: sha512-shPIpvQANjq/U7ismTe8oM2W4BoGqwZL0PtVzbNE2O1k7o2LgllSjiKaqsft3RMwh1A+5WjlIvrx+17UvT4OeA==, tarball: file:projects/smart-home.tgz}
     id: file:projects/smart-home.tgz
     name: '@rush-temp/smart-home'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.29_react-dom@17.0.2+react@17.0.2
+      '@speechly/demo-navigation': 0.1.30_react-dom@17.0.2+react@17.0.2
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 7.2.1
@@ -17820,12 +17820,12 @@ packages:
     dev: false
 
   file:projects/speech-to-text.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-UlM0B/9cCJhQyoLt0mvf4L8yZJhnNsQRTl4nVCSZVrkGtVkJnN1fl83aPa2xLqu1FIpT7v+GIKsJzBSiY7Io8g==, tarball: file:projects/speech-to-text.tgz}
+    resolution: {integrity: sha512-SbRmjBnA8PzrlIkreeU1k7O/ti/iSV44u1Wt3dC4FF9TSnJWp0e6FgHE6KOcyGI38lbxoYC9+bydTTNNBGF7aw==, tarball: file:projects/speech-to-text.tgz}
     id: file:projects/speech-to-text.tgz
     name: '@rush-temp/speech-to-text'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.29_react-dom@17.0.2+react@17.0.2
+      '@speechly/demo-navigation': 0.1.30_react-dom@17.0.2+react@17.0.2
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@17.0.2+react@17.0.2
       '@testing-library/user-event': 7.2.1

--- a/demos/ecommerce-checkout/package.json
+++ b/demos/ecommerce-checkout/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/checkout/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.29",
+    "@speechly/demo-navigation": "^0.1.30",
     "@speechly/logkit": ">=1.0.0",
     "@speechly/react-client": ">=0.0.22",
     "@speechly/react-ui": ">=2.1.2",

--- a/demos/fashion-ecommerce/package.json
+++ b/demos/fashion-ecommerce/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/fashion/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.29",
+    "@speechly/demo-navigation": "^0.1.30",
     "@speechly/react-client": ">=0.0.22",
     "@speechly/react-ui": ">=2.1.2",
     "@speechly/logkit": ">=1.0.0",

--- a/demos/flight-booking/package.json
+++ b/demos/flight-booking/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "booking",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.29",
+    "@speechly/demo-navigation": "^0.1.30",
     "@speechly/react-client": ">=0.0.22",
     "@speechly/react-ui": ">=2.1.2",
     "@speechly/react-voice-forms": ">=1.0.4",

--- a/demos/smart-home/package.json
+++ b/demos/smart-home/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "smart-home",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.29",
+    "@speechly/demo-navigation": "^0.1.30",
     "@speechly/react-client": ">=0.0.22",
     "@speechly/react-ui": ">=2.1.2",
     "@speechly/logkit": ">=1.0.0",

--- a/demos/speech-to-text/package.json
+++ b/demos/speech-to-text/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/speech-to-text/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.29",
+    "@speechly/demo-navigation": "^0.1.30",
     "@speechly/react-client": ">=0.0.22",
     "@speechly/react-ui": ">=2.1.2",
     "@speechly/logkit": ">=1.0.0",


### PR DESCRIPTION
### What

Update demo-navigation dependency that includes correct demo paths as well as fixes for Safari

### Why

It was borken