### PR TITLE
Release/react UI 2.1.3

### DIFF
--- a/common/changes/@speechly/react-ui/release-react-ui-2.1.3_2021-11-18-13-52.json
+++ b/common/changes/@speechly/react-ui/release-react-ui-2.1.3_2021-11-18-13-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-ui",
+      "comment": "react-ui built against browser-ui 5.0.1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-ui"
+}

--- a/common/changes/@speechly/react-ui/release-react-ui-2.1.3_2021-11-18-13-55.json
+++ b/common/changes/@speechly/react-ui/release-react-ui-2.1.3_2021-11-18-13-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-ui",
+      "comment": "Updated internal @speechly/browser-ui dependency to >=5.0.1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-ui"
+}

--- a/libraries/react-ui/package.json
+++ b/libraries/react-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@speechly/react-ui",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Speechly UI Components",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/libraries/react-ui/package.json
+++ b/libraries/react-ui/package.json
@@ -56,7 +56,7 @@
     "react-dom": ">=16.13.1"
   },
   "dependencies": {
-    "@speechly/browser-ui": ">=4.1.2",
+    "@speechly/browser-ui": ">=5.0.1",
     "pubsub-js": "^1.9.2",
     "react-spring": "^8.0.27",
     "styled-components": "^5.2.1"


### PR DESCRIPTION
### What

react-ui release compatible with browser-ui 5.x

### Why

Due to migration to Rush monorepo the internal structure of browser-ui package was changed. React-ui had internal browser-ui >= 4.x dependency, which didn't work with the browser-ui 5.x