### PR TITLE
Fix react-ui on Nextjs: Use dynamic browser-ui imports for SSR compability

### DIFF
--- a/common/changes/@speechly/react-ui/feature-react-ui-dynamic-browser-ui-import_2021-12-27-15-37.json
+++ b/common/changes/@speechly/react-ui/feature-react-ui-dynamic-browser-ui-import_2021-12-27-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-ui",
+      "comment": "Dynamic import of browser-ui custom elements to make react-ui play nice with Nextjs server side rendering (SSR)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@speechly/react-ui"
+}

--- a/demos/fashion-ecommerce/package.json
+++ b/demos/fashion-ecommerce/package.json
@@ -13,7 +13,7 @@
     "react-spring": "^8.0.27",
     "react-device-detect": "^1.14.0",
     "pubsub-js": "^1.9.2",
-    "styled-components": "^5.2.1",
+    "styled-components": ">=5.3.3",
     "classnames": "~2.3.1"
   },
   "devDependencies": {

--- a/demos/smart-home/package.json
+++ b/demos/smart-home/package.json
@@ -18,7 +18,7 @@
     "react-refresh": "^0.9.0",
     "react-scripts": "^4.0.3",
     "react-spring": "^8.0.27",
-    "styled-components": "^5.2.1",
+    "styled-components": ">=5.3.3",
     "typescript": "^4.3.5"
   },
   "devDependencies": {

--- a/libraries/react-ui/package.json
+++ b/libraries/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/react-ui",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Speechly UI Components",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -59,7 +59,7 @@
     "@speechly/browser-ui": ">=5.0.2",
     "pubsub-js": "^1.9.2",
     "react-spring": "^8.0.27",
-    "styled-components": "^5.2.1"
+    "styled-components": ">=5.3.3"
   },
   "files": [
     "lib/**/*"

--- a/libraries/react-ui/src/components/BigTranscript.tsx
+++ b/libraries/react-ui/src/components/BigTranscript.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { SpeechSegment, useSpeechContext } from '@speechly/react-client'
 import { mapSpeechStateToClientState } from '../types'
-import '@speechly/browser-ui/core/big-transcript'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -71,7 +70,16 @@ export const BigTranscript: React.FC<BigTranscriptProps> = ({
 }) => {
   const { segment, speechState } = useSpeechContext()
   const refElement = useRef<any>()
+  const [loaded, setLoaded] = useState(false)
   const [demoMode, setDemoMode] = useState(false)
+
+  // Dynamic import of HTML custom element to play nice with Next.js SSR
+  useEffect(() => {
+    (async () => {
+      await import('@speechly/browser-ui/core/big-transcript')
+      setLoaded(true)
+    })()
+  }, [])
 
   // Change button face according to Speechly states
   useEffect(() => {
@@ -93,6 +101,8 @@ export const BigTranscript: React.FC<BigTranscriptProps> = ({
       refElement.current.speechsegment(mockSegment)
     }
   }, [mockSegment])
+
+  if (!loaded) return null
 
   return (
     <big-transcript ref={refElement} placement={placement} demomode={demoMode ? 'true' : 'false'} formattext={(formatText !== null && formatText === false) ? 'false' : 'true'} fontsize={fontSize} color={color} highlightcolor={highlightColor} backgroundcolor={backgroundColor} marginbottom={marginBottom}></big-transcript>

--- a/libraries/react-ui/src/components/BigTranscript.tsx
+++ b/libraries/react-ui/src/components/BigTranscript.tsx
@@ -75,6 +75,7 @@ export const BigTranscript: React.FC<BigTranscriptProps> = ({
 
   // Dynamic import of HTML custom element to play nice with Next.js SSR
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       await import('@speechly/browser-ui/core/big-transcript')
       setLoaded(true)

--- a/libraries/react-ui/src/components/ErrorPanel.tsx
+++ b/libraries/react-ui/src/components/ErrorPanel.tsx
@@ -38,12 +38,13 @@ export const ErrorPanel: React.FC<ErrorPanelProps> = ({
 
   // Dynamic import of HTML custom element to play nice with Next.js SSR
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       await import('@speechly/browser-ui/core/error-panel')
       setLoaded(true)
     })()
   }, [])
-  
+
   if (!loaded) return null
 
   return (

--- a/libraries/react-ui/src/components/ErrorPanel.tsx
+++ b/libraries/react-ui/src/components/ErrorPanel.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import '@speechly/browser-ui/core/error-panel'
+import React, { useEffect, useState } from 'react'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -35,6 +34,18 @@ export type ErrorPanelProps = {
 export const ErrorPanel: React.FC<ErrorPanelProps> = ({
   placement = 'bottom',
 }) => {
+  const [loaded, setLoaded] = useState(false)
+
+  // Dynamic import of HTML custom element to play nice with Next.js SSR
+  useEffect(() => {
+    (async () => {
+      await import('@speechly/browser-ui/core/error-panel')
+      setLoaded(true)
+    })()
+  }, [])
+  
+  if (!loaded) return null
+
   return (
     <error-panel placement={placement}></error-panel>
   )

--- a/libraries/react-ui/src/components/PushToTalkButton.tsx
+++ b/libraries/react-ui/src/components/PushToTalkButton.tsx
@@ -154,6 +154,7 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
 
   // Dynamic import of HTML custom element to play nice with Next.js SSR
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       const import1 = import('@speechly/browser-ui/core/holdable-button')
       const import2 = import('@speechly/browser-ui/core/call-out')

--- a/libraries/react-ui/src/components/PushToTalkButton.tsx
+++ b/libraries/react-ui/src/components/PushToTalkButton.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useRef, useState } from 'react'
 import { SpeechState, useSpeechContext } from '@speechly/react-client'
 import PubSub from 'pubsub-js'
 import { mapSpeechStateToClientState, SpeechlyUiEvents } from '../types'
-import '@speechly/browser-ui/core/holdable-button'
-import '@speechly/browser-ui/core/call-out'
 import { PushToTalkButtonContainer } from '..'
 
 declare global {
@@ -134,6 +132,7 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
   silenceToHangupTime = 1000,
 }) => {
   const { speechState, toggleRecording, initialise, segment } = useSpeechContext()
+  const [loaded, setLoaded] = useState(false)
   const [icon, setIcon] = useState<string>((powerOn ? SpeechState.Idle : SpeechState.Ready) as string)
   const [hintText, setHintText] = useState<string>(intro)
   const [showHint, setShowHint] = useState(true)
@@ -153,6 +152,16 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
   // but they *will* see the current value whenever they do run
   speechStateRef.current = speechState
 
+  // Dynamic import of HTML custom element to play nice with Next.js SSR
+  useEffect(() => {
+    (async () => {
+      const import1 = import('@speechly/browser-ui/core/holdable-button')
+      const import2 = import('@speechly/browser-ui/core/call-out')
+      await Promise.all([import1, import2])
+      setLoaded(true)
+    })()
+  }, [])
+
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (buttonRef?.current) {
@@ -167,7 +176,6 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
     if (!powerOn && speechState === SpeechState.Idle) {
       setIcon(SpeechState.Ready as string)
     } else {
-      console.log(speechState as string)
       setIcon(speechState as string)
     }
 
@@ -257,6 +265,8 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
   const isStoppable = (s?: SpeechState): boolean => {
     return (s === SpeechState.Recording)
   }
+
+  if (!loaded) return null
 
   return (
     <div>

--- a/libraries/react-ui/src/components/TranscriptDrawer.tsx
+++ b/libraries/react-ui/src/components/TranscriptDrawer.tsx
@@ -82,12 +82,13 @@ export const TranscriptDrawer: React.FC<TranscriptDrawerProps> = props => {
 
   // Dynamic import of HTML custom element to play nice with Next.js SSR
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {
       await import('@speechly/browser-ui/core/transcript-drawer')
       setLoaded(true)
     })()
   }, [])
-  
+
   useEffect(() => {
     if (refElement?.current !== undefined) {
       refElement.current.speechstate(mapSpeechStateToClientState(speechState))

--- a/libraries/react-ui/src/components/TranscriptDrawer.tsx
+++ b/libraries/react-ui/src/components/TranscriptDrawer.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { SpeechSegment, useSpeechContext } from '@speechly/react-client'
 import { mapSpeechStateToClientState } from '../types'
-import '@speechly/browser-ui/core/transcript-drawer'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -78,8 +77,17 @@ export type TranscriptDrawerProps = {
 export const TranscriptDrawer: React.FC<TranscriptDrawerProps> = props => {
   const { segment, speechState } = useSpeechContext()
   const refElement = useRef<any>()
+  const [loaded, setLoaded] = useState(false)
   const [demoMode, setDemoMode] = useState(false)
 
+  // Dynamic import of HTML custom element to play nice with Next.js SSR
+  useEffect(() => {
+    (async () => {
+      await import('@speechly/browser-ui/core/transcript-drawer')
+      setLoaded(true)
+    })()
+  }, [])
+  
   useEffect(() => {
     if (refElement?.current !== undefined) {
       refElement.current.speechstate(mapSpeechStateToClientState(speechState))
@@ -99,6 +107,8 @@ export const TranscriptDrawer: React.FC<TranscriptDrawerProps> = props => {
       refElement.current.speechsegment(props.mockSegment)
     }
   }, [props.mockSegment])
+
+  if (!loaded) return null
 
   return (
     <transcript-drawer

--- a/libraries/react-ui/src/declarations.d.ts
+++ b/libraries/react-ui/src/declarations.d.ts
@@ -1,0 +1,5 @@
+declare module '@speechly/browser-ui/core/holdable-button'
+declare module '@speechly/browser-ui/core/call-out'
+declare module '@speechly/browser-ui/core/big-transcript'
+declare module '@speechly/browser-ui/core/transcript-drawer'
+declare module '@speechly/browser-ui/core/error-panel'


### PR DESCRIPTION

### What

Dynamic import of browser-ui custom elements in react-ui.

(Also updates `styled-components` to 5.3.3 to fix `rush build`, which is failing due to missing `react-is` dependency)

### Why

To enable Speechly with frameworks like Nextjs that use server side rendering (SSR).

Without this, Nextjs always fails when using react-ui package. The problem seems to be due to Next’s server-side rendering (SSR) of pages. React-ui internally uses custom elements aka “web components” provided by browser-ui. Next.js (like many frameworks) lack SSR of web components and it seems to drop the package and hence throw `module not found`.

This fix per a method outlined here: https://dev.to/swyx/how-to-use-web-components-with-next-js-and-typescript-4gg1

### Note

This PR is a partial fix for enabling Speechly on Nextjs. react-ui and/or browser-ui suffers from similar problems (tries to use browser APIs on server) and need to be fixed to enable Speechly on Nextjs.