### PR TITLE
Initialize Speechly on DOM mount instead of constructor to fix server-side rendering problems

### DIFF
--- a/common/changes/@speechly/react-client/fix-react-client-ssr--create-speechly-at-dom-mount_2021-12-28-09-49.json
+++ b/common/changes/@speechly/react-client/fix-react-client-ssr--create-speechly-at-dom-mount_2021-12-28-09-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-client",
+      "comment": "Initialize Speechly on DOM mount instead of constructor to fix server-side rendering problems",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-client"
+}

--- a/libraries/react-client/package.json
+++ b/libraries/react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/react-client",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "React client for Speechly SLU API",
   "private": true,
   "keywords": [
@@ -76,6 +76,9 @@
     "typedoc-plugin-markdown": "^3.0.7",
     "typescript": "^4.3.5"
   },
+  "files": [
+    "dist/**/*"
+  ],  
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
### What

- Postpone Speechly creation to DOM mount time to prevent it from happening on the server-side.

- Also fixes npm packs by explicitly including `dist/` folder in package (currently `dist/` is gitignored, so publishing to npm is currently bork)

### Why

To enable Speechly with frameworks that use server side rendering (SSR). With sister PR https://github.com/speechly/speechly/pull/113 this PR enables Speechly's React tools on frameworks like Nextjs.

Currently using Speechy with Nextjs always fails with `webWorkerController.js 63:22 - ReferenceError: Blob is not defined` when attempting to use `SpeechProvider` from `react-client` package. React-client internally initialized browser-client in SpeechProvider class constructor, which failed as browser APIs are unavailable on server side. After this PR, initialization happens upon DOM mount, which won't happen on server side.
