### PR TITLE
Fix/unwanted listening start after permission prompt

### DIFF
--- a/common/changes/@speechly/browser-ui/fix-listening-on-after-permission-prompt_2022-01-25-09-58.json
+++ b/common/changes/@speechly/browser-ui/fix-listening-on-after-permission-prompt_2022-01-25-09-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "5.0.5 fixing listening auto-starting after permission consent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/common/changes/@speechly/react-ui/fix-listening-on-after-permission-prompt_2022-01-25-10-08.json
+++ b/common/changes/@speechly/react-ui/fix-listening-on-after-permission-prompt_2022-01-25-10-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-ui",
+      "comment": "2.3.1 fixing unwanted listening start after permission prompt",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-ui"
+}

--- a/libraries/browser-ui/package.json
+++ b/libraries/browser-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/browser-ui",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "scripts": {
     "build": "rimraf core && rollup -c --silent",
     "build:watch": "rollup -c --silent",

--- a/libraries/browser-ui/src/push-to-talk-button.svelte
+++ b/libraries/browser-ui/src/push-to-talk-button.svelte
@@ -62,8 +62,6 @@
         ...(loginurl && {loginUrl: loginurl}),
         ...(apiurl && {apiUrl: apiurl}),
       }
-      console.log("Creating client with ClientOptions", clientOptions);
-
       client = new Client(clientOptions);
 
       client.onStateChange(onStateChange);
@@ -88,12 +86,10 @@
     // Make sure you call `initialize` from a user action handler (e.g. from a button press handler).
     (async () => {
       try {
-        console.log("Initializing...", client);
         dispatchUnbounded("starting");
         await client.initialize();
-        console.log("Initialized");
       } catch (e) {
-        console.log("Initialization failed", e);
+        console.error("Speechly initialization failed", e);
         client = null;
       }
     })();
@@ -109,7 +105,7 @@
           initializeSpeechly();
         } else {
           console.warn(
-            "No appid attribute specified. Speechly voice services are unavailable."
+            "No appid/projectid attribute specified. Speechly voice services are unavailable."
           );
         }
       } else {
@@ -156,14 +152,16 @@
   };
 
   const setStopContextTimeout = (timeoutMs: number) => {
-    tapListenActive = true;
-    if (tapListenTimeout) {
-      window.clearTimeout(tapListenTimeout);
+    if (isStoppable(clientState)) {
+      tapListenActive = true;
+      if (tapListenTimeout) {
+        window.clearTimeout(tapListenTimeout);
+      }
+      tapListenTimeout = window.setTimeout(() => {
+        tapListenTimeout = null;
+        stopListening();
+      }, timeoutMs);
     }
-    tapListenTimeout = window.setTimeout(() => {
-      tapListenTimeout = null;
-      stopListening();
-    }, timeoutMs);
   }
 
   const stopListening = () => {

--- a/libraries/react-ui/package.json
+++ b/libraries/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speechly/react-ui",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Speechly UI Components",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
### What

- browser-ui and react-ui no longer start listening after permission prompt

### Why

- When mic button was tapped, listening started after permission prompt
- This is undesired due to the distraction caused by the permission prompt
