### PR TITLE
use fast intent detector

### DIFF
--- a/demos/fashion-ecommerce/config/voice-interface.yaml
+++ b/demos/fashion-ecommerce/config/voice-interface.yaml
@@ -1,4 +1,5 @@
 enable_strict_nlu: true
+fast_intent_detector: true
 adaptation_audio_package: 'gs://speechly-experimental-configs-fbabb998a6fd91d0/fashion-demo-rnnt-adaptation-corpus-first-pass-5h47min.tar'
 asr_biasing: moderate
 imports:


### PR DESCRIPTION
### What
Revert fashion demo to use legacy ("fast") intent detector.

### Why
The new LSTM based intent detector does not do very well on this configuration.

