### PR TITLE
Fix/respect no tap to talk

### DIFF
--- a/common/changes/@speechly/browser-ui/fix-respect-no-tap-to-talk_2022-02-28-08-32.json
+++ b/common/changes/@speechly/browser-ui/fix-respect-no-tap-to-talk_2022-02-28-08-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "respect no tap-to-talk option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/common/changes/@speechly/react-ui/fix-respect-no-tap-to-talk_2022-02-28-08-37.json
+++ b/common/changes/@speechly/react-ui/fix-respect-no-tap-to-talk_2022-02-28-08-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-ui",
+      "comment": "respect no tap-to-talk option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-ui"
+}

--- a/libraries/browser-ui/src/push-to-talk-button.svelte
+++ b/libraries/browser-ui/src/push-to-talk-button.svelte
@@ -181,6 +181,7 @@
       // Detect short press
       if (holdEventData.timeMs < TAP_TRESHOLD_MS) {
         if (taptotalktime == 0) {
+          stopListening();
           tipCallOutText = hint;
           tipCalloutVisible = true;
         } else {

--- a/libraries/react-ui/src/components/PushToTalkButton.tsx
+++ b/libraries/react-ui/src/components/PushToTalkButton.tsx
@@ -251,6 +251,7 @@ export const PushToTalkButton: React.FC<PushToTalkButtonProps> = ({
 
       if (event.timeMs < TAP_TRESHOLD_MS) {
         if (tapToTalkTime === 0) {
+          stopListening()
           setHintText(hint)
           setShowHint(true)
         } else {


### PR DESCRIPTION
browser-ui & react-ui: Ensure stopListening() is called also when quick-tapping with tap-to-talk disabled.
