### PR TITLE
fix/react-client-example

### DIFF
--- a/examples/react-client-example/src/App.js
+++ b/examples/react-client-example/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {SpeechProvider, useSpeechContext} from '@speechly/react-client'
+import {ClientState, SpeechProvider, useSpeechContext} from '@speechly/react-client'
 
 export default function App() {
   const appId = process.env.REACT_APP_APP_ID ?? "be3bfb17-ee36-4050-8830-743aa85065ab";
@@ -17,7 +17,7 @@ export default function App() {
 }
 
 function SpeechlyApp() {
-  const {speechState, segment, listening, toggleRecording, initialize} = useSpeechContext()
+  const {clientState, segment, listening, startContext, stopContext, connect, initialize} = useSpeechContext()
 
   return (
     <div>
@@ -31,11 +31,12 @@ function SpeechlyApp() {
       <hr/>
 
 
-      <div className="status">State: {speechState}. Listening: {listening.toString()}</div>
+      <div className="status">ClientState: {clientState}. Listening: {listening.toString()}</div>
       <div className="mic-button">
-        <button onClick={initialize} disabled={speechState !== 'Idle'}>Connect</button>
-        <button onClick={toggleRecording}>
-          { listening ? 'Stop' : 'Listen' }
+        <button onClick={connect} disabled={clientState !== ClientState.Disconnected}>Connect</button>
+        <button onClick={initialize} disabled={clientState >= ClientState.Connected}>Initialize mic</button>
+        <button onMouseDown={startContext} onMouseUp={stopContext}>
+          { listening ? 'Listening...' : 'Hold to listen' }
         </button>
       </div>
       <h3>Transcript</h3>

--- a/examples/react-client-example/src/App.js
+++ b/examples/react-client-example/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ClientState, SpeechProvider, useSpeechContext} from '@speechly/react-client'
+import {ClientState, SpeechProvider, useSpeechContext, stateToString} from '@speechly/react-client'
 
 export default function App() {
   const appId = process.env.REACT_APP_APP_ID ?? "be3bfb17-ee36-4050-8830-743aa85065ab";
@@ -31,7 +31,7 @@ function SpeechlyApp() {
       <hr/>
 
 
-      <div className="status">ClientState: {clientState}. Listening: {listening.toString()}</div>
+      <div className="status">State: {stateToString(clientState)}. Listening: {listening.toString()}</div>
       <div className="mic-button">
         <button onClick={connect} disabled={clientState !== ClientState.Disconnected}>Connect</button>
         <button onClick={initialize} disabled={clientState >= ClientState.Connected}>Initialize mic</button>


### PR DESCRIPTION
### What

- Removed legacy `SpeechState` dependency and using ClientState instead.
- Changed 'Listen' button behaviour from click-to-toggle to push-to-talk
- Added separate 'Connect' and 'Initialize Mic' buttons.

### Why

- Make it work again ;)
- Make it more analogous to current browser-client-example
- Exposing 'Connect' and 'Initialize Mic' is more in line with the internals of SpeechlyClient (although you can just do 'startContext' which ensures both 'connect' and 'initialize').