### PR TITLE
browser-client: provide explicitly fetcher function

### DIFF
--- a/common/changes/@speechly/browser-client/fix-fetch-token_2022-05-30-06-34.json
+++ b/common/changes/@speechly/browser-client/fix-fetch-token_2022-05-30-06-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Fix error due to missing default argument in browser-client.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -108,7 +108,7 @@ export class CloudDecoder {
         const storedToken = this.storage.get(authTokenKey)
         if (storedToken == null || !validateToken(storedToken, this.projectId, this.appId, this.deviceId)) {
           try {
-            this.authToken = await fetchToken(this.loginUrl, this.projectId, this.appId, this.deviceId)
+            this.authToken = await fetchToken(this.loginUrl, this.projectId, this.appId, this.deviceId, fetch)
             // Cache the auth token in local storage for future use.
             this.storage.set(authTokenKey, this.authToken)
           } catch (err) {


### PR DESCRIPTION
### What

`fetchToken` function's 5th parameter has a default value `fetch`, that is not used for some reason. Give it explicitly when calling the function.

### Why

Steps to reproduce:
1. Run `localStorage.clear()` in browser console to delete current token.
2. Start *examples/browser-client-example*
3. Click Connect
4. Observe error `TypeError: fetcher is not a function`

After this change, this error does not happen and browser-client can connect normally.