### PR TITLE
Fix/error flood but no reconnect

### DIFF
--- a/common/changes/@speechly/browser-client/fix-error-flood-but-no-reconnect_2022-06-01-14-38.json
+++ b/common/changes/@speechly/browser-client/fix-error-flood-but-no-reconnect_2022-06-01-14-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Fixed reconnecting after websocket close",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/libraries/browser-client/src/audioprocessing/AudioProcessor.ts
+++ b/libraries/browser-client/src/audioprocessing/AudioProcessor.ts
@@ -140,7 +140,8 @@ class AudioProcessor {
     this.isActive = false
   }
 
-  public resetStream(): void {
+  public reset(): void {
+    this.isActive = false
     this.streamFramePos = 0
     this.streamSamplePos = 0
     this.frameSamplePos = 0

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -139,7 +139,7 @@ export class CloudDecoder {
   }
 
   /**
-   * Closes the client by closing the API connection and disabling the microphone.
+   * Closes the client by closing the API connection.
    */
   async close(): Promise<void> {
     let error: string | undefined
@@ -152,6 +152,7 @@ export class CloudDecoder {
     }
 
     this.segments.clear()
+    this.activeContexts = 0
     this.connectPromise = null
     this.setState(DecoderState.Disconnected)
 
@@ -174,6 +175,7 @@ export class CloudDecoder {
     }
     await this.apiClient.stopStream()
 
+    // Wait for active contexts to finish
     if (this.activeContexts > 0) {
       const p = new Promise(resolve => {
         this.resolveStopStream = resolve
@@ -417,6 +419,8 @@ export class CloudDecoder {
       }
 
       this.setState(DecoderState.Disconnected)
+      this.activeContexts = 0
+      this.segments.clear()
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.reconnect()
     }

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -412,6 +412,7 @@ export class CloudDecoder {
       // If for some reason deviceId is missing, there's nothing else we can do but fail completely.
       if (this.deviceId === undefined) {
         this.setState(DecoderState.Failed)
+        console.error('[Decoder]', 'No deviceId. Giving up reconnecting.')
         return
       }
 

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -230,8 +230,11 @@ class WebsocketClient {
 
     this.audioProcessor.stopContext()
     this.isContextStarted = false
-    const StopEventJSON = JSON.stringify({ event: 'stop' })
-    this.send(StopEventJSON)
+
+    if (this.websocket) {
+      const StopEventJSON = JSON.stringify({ event: 'stop' })
+      this.send(StopEventJSON)
+    }
   }
 
   switchContext(contextOptions?: ContextOptions): void {
@@ -324,8 +327,9 @@ class WebsocketClient {
   }
 
   send(data: string | Int16Array): void {
-    // We're offline, most likely due to an earlier error
-    if (!this.websocket) return
+    if (!this.websocket) {
+      throw new Error('No Websocket')
+    }
 
     if (this.websocket.readyState !== this.websocket.OPEN) {
       throw new Error(`Expected OPEN Websocket state, but got ${this.websocket.readyState}`)


### PR DESCRIPTION
### What

- Refrain from sending audio data when websocket has been closed in web worker.
- Clean up BrowserClient states when web worker signals about connection close with DecoderState.Disconnected.
- Call BrowserClient.startStream() after reconnect to resume VAD.

Reproed and tested on Chrome OS X & browser-client-example by toggling WIFI on/off during use. Tried with and without SharedArrayBuffers.

### Why

- Attempting to send audio (or anything) after websocket closure leads to error flood. It also ruined reconnect attempts as sending audio data without a context will result in a subsequent connection close.
