### PR TITLE
Feature/VAD timestamps are in relation to start stream

### DIFF
--- a/common/changes/@speechly/browser-client/feature-adjust-vad-timestamps-in-releation-to-stream_2022-06-02-12-56.json
+++ b/common/changes/@speechly/browser-client/feature-adjust-vad-timestamps-in-releation-to-stream_2022-06-02-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Word offsets are in relation to stream start. This is equal to time within audio context when not using VAD.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/examples/browser-client-example/src/index.ts
+++ b/examples/browser-client-example/src/index.ts
@@ -65,7 +65,7 @@ window.onload = () => {
 
     const cleanedWords = segment.words
       .filter((w: Word) => w.value)
-      .map((w: Word) => ({ value: w.value, index: w.index }));
+      .map((w: Word) => ({ value: w.value, index: w.index, startTimestamp: w.startTimestamp, endTimestamp: w.endTimestamp }));
 
     logResponse(
       segment.contextId,

--- a/libraries/browser-client/src/audioprocessing/AudioProcessor.ts
+++ b/libraries/browser-client/src/audioprocessing/AudioProcessor.ts
@@ -151,10 +151,10 @@ class AudioProcessor {
   }
 
   /**
-   * @returns current position in stream in seconds
+   * @returns current position in stream in milliseconds
    */
   public getStreamPosition(): number {
-    return this.streamSamplePos / this.inputSampleRate
+    return Math.round(this.streamSamplePos / this.inputSampleRate * 1000)
   }
 
   private flush(): void {

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { validateToken, fetchToken } from '../websocket/token'
 
-import { SegmentState, ErrAppIdChangeWithoutProjectLogin, Segment, AudioRange } from '../speechly'
+import { SegmentState, ErrAppIdChangeWithoutProjectLogin, Segment, SLUResults } from '../speechly'
 
 import {
   APIClient,
@@ -48,7 +48,7 @@ export class CloudDecoder {
 
   private activeContexts = 0
 
-  private readonly audioContexts = new Map<string, AudioRange>()
+  private readonly audioContexts = new Map<string, SLUResults>()
   private readonly maxReconnectAttemptCount = 10
 
   private connectAttempt: number = 0

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -331,7 +331,7 @@ export class CloudDecoder {
   }
 
   private readonly handleSegmentUpdate = (response: WebsocketResponse): void => {
-    const { audio_context, segment_id, type } = response
+    const { audio_context, segment_id, type, context_start_in_stream_millis } = response
     let { data } = response
 
     const context = this.segments.get(audio_context)
@@ -345,14 +345,14 @@ export class CloudDecoder {
     switch (type) {
       case WebsocketResponseType.TentativeTranscript:
         data = data as TentativeTranscriptResponse
-        const words = parseTentativeTranscript(data)
+        const words = parseTentativeTranscript(data, context_start_in_stream_millis)
         const transcript = data.transcript
         this.cbs.forEach(cb => cb.tentativeTranscriptCbs.forEach(f => f(audio_context, segment_id, words, transcript)))
         segmentState = segmentState.updateTranscript(words)
         break
       case WebsocketResponseType.Transcript:
         data = data as TranscriptResponse
-        const word = parseTranscript(data)
+        const word = parseTranscript(data, context_start_in_stream_millis)
         this.cbs.forEach(cb => cb.transcriptCbs.forEach(f => f(audio_context, segment_id, word)))
         segmentState = segmentState.updateTranscript([word])
         break

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { validateToken, fetchToken } from '../websocket/token'
 
-import { SegmentState, ErrAppIdChangeWithoutProjectLogin, Segment } from '../speechly'
+import { SegmentState, ErrAppIdChangeWithoutProjectLogin, Segment, AudioRange } from '../speechly'
 
 import {
   APIClient,
@@ -48,7 +48,7 @@ export class CloudDecoder {
 
   private activeContexts = 0
 
-  private readonly segments = new Map<string, Map<number, SegmentState>>()
+  private readonly audioContexts = new Map<string, AudioRange>()
   private readonly maxReconnectAttemptCount = 10
 
   private connectAttempt: number = 0
@@ -151,7 +151,7 @@ export class CloudDecoder {
       error = err.message
     }
 
-    this.segments.clear()
+    this.audioContexts.clear()
     this.activeContexts = 0
     this.connectPromise = null
     this.setState(DecoderState.Disconnected)
@@ -163,7 +163,7 @@ export class CloudDecoder {
 
   async startStream(streamOptions: StreamOptions): Promise<void> {
     this.streamOptions = streamOptions
-    this.segments.clear()
+    this.audioContexts.clear()
     this.activeContexts = 0
 
     await this.apiClient.startStream()
@@ -260,7 +260,7 @@ export class CloudDecoder {
    * by sending a start context event to the API and unmuting the microphone.
    * @param options - any custom options for the audio processing.
    */
-  async switchContext(options: ContextOptions): Promise<void> {
+  async switchContext(options: ContextOptions): Promise<string> {
     if (this.state !== DecoderState.Active) {
       throw Error(
         '[Decoder] Unable to complete switchContext: Expected Active state, but was in ' +
@@ -269,7 +269,7 @@ export class CloudDecoder {
       )
     }
     const contextId = await this.apiClient.switchContext(options)
-    this.segments.set(contextId, new Map<number, SegmentState>())
+    return contextId
   }
 
   registerListener(listener: EventCallbacks): void {
@@ -307,7 +307,11 @@ export class CloudDecoder {
         break
       case WebsocketResponseType.Started: {
         this.activeContexts++
-        this.segments.set(response.audio_context, new Map<number, SegmentState>())
+        const params = response.params
+        this.audioContexts.set(response.audio_context, {
+          segments: new Map(),
+          audioStartTimeMillis: params.audioStartTimeMillis,
+        })
         this.cbs.forEach(cb => cb.contextStartedCbs.forEach(f => f(response.audio_context)))
         break
       }
@@ -315,7 +319,7 @@ export class CloudDecoder {
         this.activeContexts--
         this.cbs.forEach(cb => cb.contextStoppedCbs.forEach(f => f(response.audio_context)))
         if (!this.streamOptions.preserveSegments) {
-          this.segments.delete(response.audio_context)
+          this.audioContexts.delete(response.audio_context)
         }
 
         // Signal stopStream listeners that the final results are in, it's ok to resolve the await
@@ -331,28 +335,28 @@ export class CloudDecoder {
   }
 
   private readonly handleSegmentUpdate = (response: WebsocketResponse): void => {
-    const { audio_context, segment_id, type, context_start_in_stream_millis } = response
+    const { audio_context, segment_id, type } = response
     let { data } = response
 
-    const context = this.segments.get(audio_context)
+    const context = this.audioContexts.get(audio_context)
     if (context === undefined) {
       console.warn('[Decoder]', 'Received response for non-existent context', audio_context)
       return
     }
 
-    let segmentState = context.get(segment_id) ?? new SegmentState(audio_context, segment_id)
+    let segmentState = context.segments.get(segment_id) ?? new SegmentState(audio_context, segment_id)
 
     switch (type) {
       case WebsocketResponseType.TentativeTranscript:
         data = data as TentativeTranscriptResponse
-        const words = parseTentativeTranscript(data, context_start_in_stream_millis)
+        const words = parseTentativeTranscript(data, context.audioStartTimeMillis)
         const transcript = data.transcript
         this.cbs.forEach(cb => cb.tentativeTranscriptCbs.forEach(f => f(audio_context, segment_id, words, transcript)))
         segmentState = segmentState.updateTranscript(words)
         break
       case WebsocketResponseType.Transcript:
         data = data as TranscriptResponse
-        const word = parseTranscript(data, context_start_in_stream_millis)
+        const word = parseTranscript(data, context.audioStartTimeMillis)
         this.cbs.forEach(cb => cb.transcriptCbs.forEach(f => f(audio_context, segment_id, word)))
         segmentState = segmentState.updateTranscript([word])
         break
@@ -388,10 +392,10 @@ export class CloudDecoder {
     }
 
     // Update the segment in current context.
-    context.set(segment_id, segmentState)
+    context.segments.set(segment_id, segmentState)
 
     // Update current contexts.
-    this.segments.set(audio_context, context)
+    this.audioContexts.set(audio_context, context)
 
     // Log segment to console
     if (this.logSegments) {
@@ -420,7 +424,7 @@ export class CloudDecoder {
 
       this.setState(DecoderState.Disconnected)
       this.activeContexts = 0
-      this.segments.clear()
+      this.audioContexts.clear()
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.reconnect()
     }
@@ -465,8 +469,8 @@ export class CloudDecoder {
    */
   getSegments(): Segment[] {
     const result: Segment[] = []
-    this.segments.forEach((segments, _) => {
-      segments.forEach((segment, _) => {
+    this.audioContexts.forEach((audioContext, _) => {
+      audioContext.segments.forEach((segment, _) => {
         const deepCopy = JSON.parse(JSON.stringify(segment))
         result.push(deepCopy)
       })

--- a/libraries/browser-client/src/client/parsers.ts
+++ b/libraries/browser-client/src/client/parsers.ts
@@ -7,24 +7,24 @@ import {
 } from '../websocket'
 import { Word, Entity, Intent } from '../speechly'
 
-export function parseTentativeTranscript(data: TentativeTranscriptResponse): Word[] {
+export function parseTentativeTranscript(data: TentativeTranscriptResponse, timeOffset: number): Word[] {
   return data.words.map(({ word, index, start_timestamp, end_timestamp }) => {
     return {
       value: word,
       index: index,
-      startTimestamp: start_timestamp,
-      endTimestamp: end_timestamp,
+      startTimestamp: start_timestamp + timeOffset,
+      endTimestamp: end_timestamp + timeOffset,
       isFinal: false,
     }
   })
 }
 
-export function parseTranscript(data: TranscriptResponse): Word {
+export function parseTranscript(data: TranscriptResponse, timeOffset: number): Word {
   return {
     value: data.word,
     index: data.index,
-    startTimestamp: data.start_timestamp,
-    endTimestamp: data.end_timestamp,
+    startTimestamp: data.start_timestamp + timeOffset,
+    endTimestamp: data.end_timestamp + timeOffset,
     isFinal: true,
   }
 }

--- a/libraries/browser-client/src/speechly/types.ts
+++ b/libraries/browser-client/src/speechly/types.ts
@@ -134,7 +134,10 @@ export interface Entity {
   isFinal: boolean
 }
 
-export interface AudioRange {
+/**
+ * A structure to accumulate SLU results for one audio context
+ */
+export interface SLUResults {
   segments: Map<number, SegmentState>
   audioStartTimeMillis: number
 }

--- a/libraries/browser-client/src/speechly/types.ts
+++ b/libraries/browser-client/src/speechly/types.ts
@@ -1,3 +1,5 @@
+import { SegmentState } from './segment'
+
 /**
  * Error to be thrown when the device does not support audioContext.
  * @public
@@ -130,4 +132,9 @@ export interface Entity {
    * Whether the entity was detected as final.
    */
   isFinal: boolean
+}
+
+export interface AudioRange {
+  segments: Map<number, SegmentState>
+  audioStartTimeMillis: number
 }

--- a/libraries/browser-client/src/speechly/types.ts
+++ b/libraries/browser-client/src/speechly/types.ts
@@ -86,12 +86,12 @@ export interface Word {
   index: number
 
   /**
-   * Start timestamp of the word within the audio of the context.
+   * Start timestamp of the word from the start of the audio stream.
    */
   startTimestamp: number
 
   /**
-   * End timestamp of the word within the audio of the context.
+   * End timestamp of the word from start of the audio stream.
    */
   endTimestamp: number
 

--- a/libraries/browser-client/src/websocket/types.ts
+++ b/libraries/browser-client/src/websocket/types.ts
@@ -33,7 +33,7 @@ export interface WebsocketResponse {
    * Context start offset from beginning of the stream in milliseconds
    * Added by the client, not provided by the backend
    */
-   context_start_in_stream_millis: number
+  context_start_in_stream_millis: number
 }
 
 /**

--- a/libraries/browser-client/src/websocket/types.ts
+++ b/libraries/browser-client/src/websocket/types.ts
@@ -30,10 +30,10 @@ export interface WebsocketResponse {
   data: TranscriptResponse | EntityResponse | IntentResponse | TentativeTranscriptResponse | TentativeEntitiesResponse
 
   /**
-   * Context start offset from beginning of the stream in milliseconds
-   * Added by the client, not provided by the backend
+   * Optional client-side metadata associated to the response.
+   * The payload value, if present, should match the response type.
    */
-  context_start_in_stream_millis: number
+  params?: StartContextParams
 }
 
 /**
@@ -81,6 +81,10 @@ export enum ControllerSignal {
   startStream = 'startStream',
   stopStream = 'stopStream',
   setContextOptions = 'setContextOptions',
+}
+
+export interface StartContextParams {
+  audioStartTimeMillis: number
 }
 
 /**
@@ -292,5 +296,4 @@ export interface APIClient {
    * also override the options per function call.
    */
   setContextOptions(options: ContextOptions): Promise<void>
-
 }

--- a/libraries/browser-client/src/websocket/types.ts
+++ b/libraries/browser-client/src/websocket/types.ts
@@ -28,6 +28,12 @@ export interface WebsocketResponse {
    * TentativeIntent and Intent share the same payload interface (IntentResponse).
    */
   data: TranscriptResponse | EntityResponse | IntentResponse | TentativeTranscriptResponse | TentativeEntitiesResponse
+
+  /**
+   * Context start offset from beginning of the stream in milliseconds
+   * Added by the client, not provided by the backend
+   */
+   context_start_in_stream_millis: number
 }
 
 /**


### PR DESCRIPTION
### What

- Word offsets are in relation to stream start.

`startTimestamp` and `endTimestamp` equal to the offset within audio context when using start/stop manually or when using file upload without VAD. This is achieved via automatic audio stream control upon start/stop context.

For clarification, audio stream in this context is a piece of continuous audio. In most cases, automation handles signalling the stream start and stop and the developer needs not concern about this. Rarely, controlling the stream manually may be relevant if the developer pauses an external audio source passed to BrowserClient.

### Why

- Word timestamps match the source audio also when VAD produces multiple audio contexts.
