### PR TITLE
Fix/sample rate on Firefox and Safari

### DIFF
--- a/common/changes/@speechly/browser-client/fix-sample-rate-on-ff-and-safari_2022-06-14-13-28.json
+++ b/common/changes/@speechly/browser-client/fix-sample-rate-on-ff-and-safari_2022-06-14-13-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Source sample rate was reset upon startStream causing Firefox and Safari to send 44kHz data instead of downsampling it to 16kHz.\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -38,6 +38,7 @@ export class BrowserClient {
   private stream?: MediaStreamAudioSourceNode
   private listeningPromise: Promise<any> | null = null
   private readonly decoderOptions: ResolvedDecoderOptions & { vad?: VadOptions }
+  private streamOptions: StreamOptions = { ...StreamDefaultOptions }
 
   private stats = {
     maxSignalEnergy: 0.0,
@@ -191,7 +192,8 @@ export class BrowserClient {
     if (this.debug) {
       console.log('[BrowserClient]', 'audioContext sampleRate is', this.audioContext?.sampleRate)
     }
-    await this.decoder.initAudioProcessor(this.audioContext?.sampleRate, this.decoderOptions.frameMillis, this.decoderOptions.historyFrames, this.decoderOptions.vad)
+    this.streamOptions.sampleRate = this.audioContext?.sampleRate
+    await this.decoder.initAudioProcessor(this.streamOptions.sampleRate, this.decoderOptions.frameMillis, this.decoderOptions.historyFrames, this.decoderOptions.vad)
     this.audioProcessorInitialized = true
 
     if (options?.mediaStream) {
@@ -392,8 +394,8 @@ export class BrowserClient {
    * @param streamOptionOverrides - options for stream processing
    */
   async startStream(streamOptionOverrides?: Partial<StreamOptions>): Promise<void> {
-    const streamOptions = { ...StreamDefaultOptions, ...streamOptionOverrides }
-    await this.decoder.startStream(streamOptions)
+    this.streamOptions = { ...this.streamOptions, ...streamOptionOverrides }
+    await this.decoder.startStream(this.streamOptions)
     this.isStreaming = true
   }
 

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -284,9 +284,8 @@ export class CloudDecoder {
     this.cbs.push(listener)
   }
 
-  async initAudioProcessor(sampleRate: number, frameMillis: number, historyFrames: number, vadOptions?: VadOptions): Promise<void> {
-    this.sampleRate = sampleRate
-    await this.apiClient.initAudioProcessor(sampleRate, frameMillis, historyFrames, vadOptions)
+  async initAudioProcessor(sourceSampleRate: number, frameMillis: number, historyFrames: number, vadOptions?: VadOptions): Promise<void> {
+    await this.apiClient.initAudioProcessor(sourceSampleRate, frameMillis, historyFrames, vadOptions)
   }
 
   useSharedArrayBuffers(controlSAB: any, dataSAB: any): void {


### PR DESCRIPTION
### What

- Prevented microphone sample rate from resetting to default upon call to startStream.

### Why

- Firefox and Safari were sending 44kHz mic data instead of downsampling it to 16kHz. As a result no valid ASR was sent back.