### PR TITLE
Fix HTML code example

### DIFF
--- a/common/changes/@speechly/browser-client/langma-patch-1_2022-06-28-10-02.json
+++ b/common/changes/@speechly/browser-client/langma-patch-1_2022-06-28-10-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/libraries/browser-client/README.md
+++ b/libraries/browser-client/README.md
@@ -134,7 +134,7 @@ Please use a HTML server to view the example. Running it as a file will not work
       const startListening = async () => {
         if (microphone.mediaStream === undefined) {
           await microphone.initialize()
-          speechly.attach(microphone.mediaStream)
+          await speechly.attach(microphone.mediaStream)
         }
         return speechly.start();
       }


### PR DESCRIPTION
Add the missing `await` from client's attach call, making the following `start()` call use the initialised AudioProcessor properly.

Fixes https://github.com/speechly/speechly/issues/210.
