### PR TITLE
Use history without VAD

### DIFF
--- a/common/changes/@speechly/browser-client/fix-use-history-without-vad_2022-08-11-18-02.json
+++ b/common/changes/@speechly/browser-client/fix-use-history-without-vad_2022-08-11-18-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Fixed honoring user-initiated startStream(). It should keep streaming audio to AudioProcessor to be able to send historyFrames upon start(). The stream was incorrectly paused upon call to stop(), which should only happen for automatically started streams when VAD is not in use.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -248,7 +248,7 @@ export class BrowserClient {
       await this.initialize()
       if (!this.isStreaming) {
         // Automatically control streaming for backwards compability
-        await this.startStream( {autoStarted: true} )
+        await this.startStream({ autoStarted: true })
       }
       const startPromise = this.decoder.startContext(options)
       return startPromise
@@ -443,14 +443,13 @@ export class BrowserClient {
 
     // Auto-start stream if VAD is enabled
     if (this.decoderOptions.vad?.enabled && !this.isStreaming) {
-      await this.startStream( {autoStarted: true} )
+      await this.startStream({ autoStarted: true })
       return
     }
 
     // Auto-stop stream if automatically started
     if (!this.decoderOptions.vad?.enabled && this.isStreaming && this.streamOptions.autoStarted) {
       await this.stopStream()
-      return
     }
   }
 

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -248,7 +248,7 @@ export class BrowserClient {
       await this.initialize()
       if (!this.isStreaming) {
         // Automatically control streaming for backwards compability
-        await this.startStream()
+        await this.startStream( {autoStarted: true} )
       }
       const startPromise = this.decoder.startContext(options)
       return startPromise
@@ -394,7 +394,7 @@ export class BrowserClient {
    * @param streamOptionOverrides - options for stream processing
    */
   async startStream(streamOptionOverrides?: Partial<StreamOptions>): Promise<void> {
-    this.streamOptions = { ...this.streamOptions, ...streamOptionOverrides }
+    this.streamOptions = { ...this.streamOptions, autoStarted: false, ...streamOptionOverrides }
     await this.decoder.startStream(this.streamOptions)
     this.isStreaming = true
   }
@@ -443,12 +443,14 @@ export class BrowserClient {
 
     // Auto-start stream if VAD is enabled
     if (this.decoderOptions.vad?.enabled && !this.isStreaming) {
-      await this.startStream()
+      await this.startStream( {autoStarted: true} )
+      return
     }
 
-    // Auto-stop stream if VAD is no longer enabled
-    if (!this.decoderOptions.vad?.enabled && this.isStreaming) {
+    // Auto-stop stream if automatically started
+    if (!this.decoderOptions.vad?.enabled && this.isStreaming && this.streamOptions.autoStarted) {
       await this.stopStream()
+      return
     }
   }
 

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -195,12 +195,18 @@ export interface StreamOptions {
    * @internal
    */
   immediate: boolean
+  /**
+   * True if stream has been automatically started.
+   * @internal
+   */
+  autoStarted: boolean
 }
 
 export const StreamDefaultOptions: StreamOptions = {
   preserveSegments: false,
   sampleRate: DefaultSampleRate,
   immediate: false,
+  autoStarted: false,
 }
 
 /**


### PR DESCRIPTION


### What

- Stream options contains an internal autostart flag
- Only autostarted streaming to AudioProcessor is automatically stopped.

### Why

- Fixed honoring user-initiated startStream(). It should keep streaming audio to AudioProcessor to be able to send historyFrames upon start(). The stream was incorrectly paused upon call to stop(), which should only happen for automatically started streams when VAD is not in use.

