### PR TITLE
add non_streaming_nlu flag to ContextOptions

### DIFF
--- a/common/changes/@speechly/browser-client/update-non-streaming-nlu-flag_2022-10-11-13-01.json
+++ b/common/changes/@speechly/browser-client/update-non-streaming-nlu-flag_2022-10-11-13-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "ContextOptions.nonStreamingNlu flag for performing NLU detection for final utterance only.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -285,4 +285,10 @@ export interface ContextOptions {
    * e.g. "Africa/Abidjan". Timezone should be wrapped to list, like ["Africa/Abidjan"].
    */
   timezone?: string[]
+
+  /**
+   * Inference time setting to use the non-streaming NLU variant. Set value to ["yes"] to enable,
+   * (or to ["no"] to disable for the current context if this parameter is enabled in the configuration).
+   */
+  nonStreamingNlu?: string[]
 }

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -287,8 +287,8 @@ export interface ContextOptions {
   timezone?: string[]
 
   /**
-   * Inference time setting to use the non-streaming NLU variant. Set value to ["yes"] to enable,
-   * (or to ["no"] to disable for the current context if this parameter is enabled in the configuration).
+   * Inference time setting to use the non-streaming NLU variant. Set value to true to enable,
+   * (or to false to disable for the current context if this parameter is enabled in the configuration).
    */
-  nonStreamingNlu?: string[]
+  nonStreamingNlu?: boolean
 }

--- a/libraries/browser-client/src/websocket/worker.test.ts
+++ b/libraries/browser-client/src/websocket/worker.test.ts
@@ -30,7 +30,7 @@ describe('worker', () => {
       worker.initAudioProcessor(16000, 30, 5)
       const mockSend = jest.spyOn(worker, 'send').mockImplementation()
       worker.startContext()
-      expect(mockSend).toHaveBeenCalledWith(JSON.stringify({ options: { timezone: [Intl.DateTimeFormat().resolvedOptions().timeZone] }, event: 'start' }))
+      expect(mockSend).toHaveBeenCalledWith(JSON.stringify({ options: { timezone: [Intl.DateTimeFormat().resolvedOptions().timeZone], non_streaming_nlu: ['no'] }, event: 'start' }))
     })
     test('startContext with options', async () => {
       // @ts-ignore
@@ -39,7 +39,7 @@ describe('worker', () => {
       const mockSend = jest.spyOn(worker, 'send').mockImplementation()
       const options: ContextOptions = { timezone: ['TZ'], vocabulary: ['W'] }
       worker.startContext(options)
-      expect(mockSend).toHaveBeenCalledWith(JSON.stringify({ options: options, event: 'start' }))
+      expect(mockSend).toHaveBeenCalledWith(JSON.stringify({ options: { timezone: ['TZ'], vocabulary: ['W'], non_streaming_nlu: ['no'] }, event: 'start' }))
     })
     test('default options', async () => {
       // @ts-ignore
@@ -49,7 +49,7 @@ describe('worker', () => {
       worker.setContextOptions({ vocabularyBias: ['0.2'], timezone: ['DEF_TZ'] })
       worker.startContext({})
       expect(mockSend).toHaveBeenCalledWith(
-        JSON.stringify({ options: { timezone: ['DEF_TZ'], vocabulary_bias: ['0.2'] }, event: 'start' }),
+        JSON.stringify({ options: { timezone: ['DEF_TZ'], vocabulary_bias: ['0.2'], non_streaming_nlu: ['no'] }, event: 'start' }),
       )
     })
     test('default options + startContext with options', async () => {
@@ -60,7 +60,7 @@ describe('worker', () => {
       worker.setContextOptions({ vocabularyBias: ['0.2'], timezone: ['DEF_TZ'] })
       worker.startContext({ timezone: ['TZ'], vocabulary: ['W'] })
       expect(mockSend).toHaveBeenCalledWith(
-        JSON.stringify({ options: { timezone: ['TZ'], vocabulary: ['W'], vocabulary_bias: ['0.2'] }, event: 'start' }),
+        JSON.stringify({ options: { timezone: ['TZ'], vocabulary: ['W'], vocabulary_bias: ['0.2'], non_streaming_nlu: ['no'] }, event: 'start' }),
       )
     })
   })

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -384,6 +384,7 @@ export function contextOptionsToMsg(contextOptions?: ContextOptions): Record<str
   message.options.vocabulary = contextOptions.vocabulary
   message.options.vocabulary_bias = contextOptions.vocabularyBias
   message.options.silence_triggered_segmentation = contextOptions.silenceTriggeredSegmentation
+  message.options.non_streaming_nlu = contextOptions.nonStreamingNlu
   if (contextOptions?.timezone !== undefined) {
     message.options.timezone = contextOptions?.timezone // override browser timezone
   }

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -384,7 +384,11 @@ export function contextOptionsToMsg(contextOptions?: ContextOptions): Record<str
   message.options.vocabulary = contextOptions.vocabulary
   message.options.vocabulary_bias = contextOptions.vocabularyBias
   message.options.silence_triggered_segmentation = contextOptions.silenceTriggeredSegmentation
-  message.options.non_streaming_nlu = contextOptions.nonStreamingNlu
+  if (contextOptions.nonStreamingNlu) {
+    message.options.non_streaming_nlu = ['yes']
+  } else {
+    message.options.non_streaming_nlu = ['no']
+  }
   if (contextOptions?.timezone !== undefined) {
     message.options.timezone = contextOptions?.timezone // override browser timezone
   }


### PR DESCRIPTION
Once the non-streaming NLU variant is enabled in the back-end, these changes should allow specifying at inference time which NLU variant to use.