### PR TITLE
Fix/BrowserClient errors when rapidly clicking hold-to-talk button

### DIFF
--- a/common/changes/@speechly/browser-client/fix-browser-client-click-spam_2022-10-13-07-58.json
+++ b/common/changes/@speechly/browser-client/fix-browser-client-click-spam_2022-10-13-07-58.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@speechly/browser-client",
-      "comment": "Fixed problem when calling BrowserClient.start() and stop() quickly multiple times.",
-      "type": "patch"
+      "comment": "Fixed problem when calling BrowserClient.start() and stop() quickly multiple times. Stop() can be awaited to return the stopped context id.",
+      "type": "minor"
     }
   ],
   "packageName": "@speechly/browser-client"

--- a/common/changes/@speechly/browser-client/fix-browser-client-click-spam_2022-10-13-07-58.json
+++ b/common/changes/@speechly/browser-client/fix-browser-client-click-spam_2022-10-13-07-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Fixed problem when calling BrowserClient.start() and stop() quickly multiple times.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/common/changes/@speechly/react-client/fix-browser-client-click-spam_2022-10-13-09-55.json
+++ b/common/changes/@speechly/react-client/fix-browser-client-click-spam_2022-10-13-09-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-client",
+      "comment": "stop() returns stopped contextId",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-client"
+}

--- a/common/changes/@speechly/react-client/fix-browser-client-click-spam_2022-10-13-09-55.json
+++ b/common/changes/@speechly/react-client/fix-browser-client-click-spam_2022-10-13-09-55.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@speechly/react-client",
-      "comment": "stop() returns stopped contextId",
-      "type": "patch"
+      "comment": "Fixed problem when calling BrowserClient.start() and stop() quickly multiple times. Stop() can be awaited to return the stopped context id.",
+      "type": "minor"
     }
   ],
   "packageName": "@speechly/react-client"

--- a/libraries/browser-client/docs/classes/client.BrowserClient.md
+++ b/libraries/browser-client/docs/classes/client.BrowserClient.md
@@ -138,7 +138,7 @@ ___
 
 ### stop
 
-▸ **stop**(`stopDelayMs?`): `Promise`<`void`\>
+▸ **stop**(`stopDelayMs?`): `Promise`<`string`\>
 
 Stops the current audio context and deactivates the audio processing pipeline.
 If there is no active audio context, a warning is logged to console.
@@ -151,7 +151,7 @@ If there is no active audio context, a warning is logged to console.
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`<`string`\>
 
 ___
 

--- a/libraries/browser-client/docs/interfaces/client.ContextOptions.md
+++ b/libraries/browser-client/docs/interfaces/client.ContextOptions.md
@@ -15,6 +15,7 @@ Valid options for a new audioContext. All options are optional.
 - [vocabularyBias](client.ContextOptions.md#vocabularybias)
 - [silenceTriggeredSegmentation](client.ContextOptions.md#silencetriggeredsegmentation)
 - [timezone](client.ContextOptions.md#timezone)
+- [nonStreamingNlu](client.ContextOptions.md#nonstreamingnlu)
 
 ## Properties
 
@@ -54,3 +55,12 @@ ___
 
 Inference timezone in [TZ database format](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 e.g. "Africa/Abidjan". Timezone should be wrapped to list, like ["Africa/Abidjan"].
+
+___
+
+### nonStreamingNlu
+
+• `Optional` **nonStreamingNlu**: `boolean`
+
+Inference time setting to use the non-streaming NLU variant. Set value to true to enable,
+(or to false to disable for the current context if this parameter is enabled in the configuration).

--- a/libraries/browser-client/docs/modules/client.md
+++ b/libraries/browser-client/docs/modules/client.md
@@ -25,6 +25,8 @@
 - [DecoderDefaultOptions](client.md#decoderdefaultoptions)
 - [VadDefaultOptions](client.md#vaddefaultoptions)
 - [StreamDefaultOptions](client.md#streamdefaultoptions)
+- [ErrAlreadyStarted](client.md#erralreadystarted)
+- [ErrAlreadyStopped](client.md#erralreadystopped)
 
 ### Enumerations
 
@@ -79,3 +81,19 @@ ___
 ### StreamDefaultOptions
 
 • `Const` **StreamDefaultOptions**: [`StreamOptions`](../interfaces/client.StreamOptions.md)
+
+___
+
+### ErrAlreadyStarted
+
+• `Const` **ErrAlreadyStarted**: `Error`
+
+Error to be thrown when BrowserClient is already started
+
+___
+
+### ErrAlreadyStopped
+
+• `Const` **ErrAlreadyStopped**: `Error`
+
+Error to be thrown when BrowserClient is already stopped

--- a/libraries/browser-client/src/audioprocessing/EnergyThresholdVAD.ts
+++ b/libraries/browser-client/src/audioprocessing/EnergyThresholdVAD.ts
@@ -42,11 +42,13 @@ class EnergyTresholdVAD {
     this.baselineEnergy = -1
   }
 
-  public processFrame(floats: Float32Array, start = 0, length = -1): void {
+  public processFrame(floats: Float32Array, start = 0, length = -1, eos: boolean = false): void {
     if (!this.vadOptions.enabled) {
       this.resetVAD()
       return
     }
+
+    if (eos) return
 
     this.energy = AudioTools.getEnergy(floats, start, length)
 

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -1,4 +1,4 @@
-import { DecoderState, EventCallbacks, DecoderOptions, ContextOptions, VadDefaultOptions, AudioProcessorParameters, StreamOptions, StreamDefaultOptions, DecoderDefaultOptions, ResolvedDecoderOptions, VadOptions } from './types'
+import { DecoderState, EventCallbacks, DecoderOptions, ContextOptions, VadDefaultOptions, AudioProcessorParameters, StreamOptions, StreamDefaultOptions, DecoderDefaultOptions, ResolvedDecoderOptions, VadOptions, ErrAlreadyStarted, ErrAlreadyStopped } from './types'
 import { CloudDecoder } from './decoder'
 import { ErrDeviceNotSupported, DefaultSampleRate, Segment, Word, Entity, Intent } from '../speechly'
 
@@ -242,42 +242,55 @@ export class BrowserClient {
    * @returns The contextId of the active audio context
    */
   async start(options?: ContextOptions): Promise<string> {
+    if (this.active) {
+      throw ErrAlreadyStarted;
+    }
+
     this.active = true
 
-    const promise = await this.queueTask(async () => {
+    const contextId = await this.queueTask(async () => {
       await this.initialize()
       if (!this.isStreaming) {
         // Automatically control streaming for backwards compability
         await this.startStream({ autoStarted: true })
       }
-      const startPromise = this.decoder.startContext(options)
-      return startPromise
+      const contextId = await this.decoder.startContext(options)
+      return contextId
     })
-    return promise
+    return contextId
   }
 
   /**
    * Stops the current audio context and deactivates the audio processing pipeline.
    * If there is no active audio context, a warning is logged to console.
    */
-  async stop(stopDelayMs = this.contextStopDelay): Promise<void> {
+  async stop(stopDelayMs = this.contextStopDelay): Promise<string> {
+    if (!this.active) {
+      throw ErrAlreadyStopped;
+    }
+
     this.active = false
 
-    await this.queueTask(async () => {
+    const contextId = await this.queueTask(async () => {
       try {
-        await this.decoder.stopContext(stopDelayMs)
+        const contextId = await this.decoder.stopContext(stopDelayMs)
         // Automatically control streaming for backwards compability
-        await this.autoControlStream()
+        if (!this.decoderOptions.vad?.enabled && this.isStreaming && this.streamOptions.autoStarted) {
+          await this.stopStream()
+        }
 
         if (this.stats.sentSamples === 0) {
           console.warn('[BrowserClient]', 'audioContext contained no audio data')
         }
+        return contextId;
       } catch (err) {
         console.warn('[BrowserClient]', 'stop() failed', err)
       } finally {
         this.stats.sentSamples = 0
       }
     })
+
+    return contextId;
   }
 
   /**
@@ -302,8 +315,16 @@ export class BrowserClient {
       }
     }
     this.decoder.adjustAudioProcessor(ap)
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.autoControlStream()
+
+    if (this.decoderOptions.vad?.enabled) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.autoControlStream()
+    } else {
+      if (this.active) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.stop()
+      }
+    }
   }
 
   /**
@@ -406,9 +427,7 @@ export class BrowserClient {
    * Use `startStream` to resume audio processing afterwards.
    */
   async stopStream(): Promise<void> {
-    this.active = false
     this.isStreaming = false
-    this.listeningPromise = null
     await this.decoder.stopStream()
   }
 
@@ -459,10 +478,6 @@ export class BrowserClient {
       case DecoderState.Failed:
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.stopStream()
-        break
-      case DecoderState.Connected:
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.autoControlStream()
         break
     }
   }

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -243,7 +243,7 @@ export class BrowserClient {
    */
   async start(options?: ContextOptions): Promise<string> {
     if (this.active) {
-      throw ErrAlreadyStarted;
+      throw ErrAlreadyStarted
     }
 
     this.active = true
@@ -266,7 +266,7 @@ export class BrowserClient {
    */
   async stop(stopDelayMs = this.contextStopDelay): Promise<string> {
     if (!this.active) {
-      throw ErrAlreadyStopped;
+      throw ErrAlreadyStopped
     }
 
     this.active = false
@@ -282,7 +282,7 @@ export class BrowserClient {
         if (this.stats.sentSamples === 0) {
           console.warn('[BrowserClient]', 'audioContext contained no audio data')
         }
-        return contextId;
+        return contextId
       } catch (err) {
         console.warn('[BrowserClient]', 'stop() failed', err)
       } finally {
@@ -290,7 +290,7 @@ export class BrowserClient {
       }
     })
 
-    return contextId;
+    return contextId
   }
 
   /**
@@ -351,6 +351,7 @@ export class BrowserClient {
       }
     }
 
+    if (this.active) await this.stop(0)
     if (this.isStreaming) await this.stopStream()
 
     await this.startStream({

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -245,7 +245,7 @@ export class CloudDecoder {
    * Stops current SLU context by sending a stop context event to the API and muting the microphone
    * delayed by contextStopDelay = 250 ms
    */
-  async stopContext(stopDelayMs: number): Promise<void> {
+  async stopContext(stopDelayMs: number): Promise<string> {
     if (this.state === DecoderState.Failed) {
       throw Error('[Decoder] stopContext cannot be run in unrecovable error state.')
     } else if (this.state !== DecoderState.Active) {
@@ -258,9 +258,9 @@ export class CloudDecoder {
     if (stopDelayMs > 0) {
       await this.sleep(stopDelayMs)
     }
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.apiClient.stopContext()
+    const contextId = await this.apiClient.stopContext()
     this.setState(DecoderState.Connected)
+    return contextId;
   }
 
   /**

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -178,11 +178,12 @@ export class CloudDecoder {
       console.log('[Decoder]', 'stopStream')
     }
 
-    if (this.state === DecoderState.Active) {
-      await this.stopContext(0)
-    }
     await this.apiClient.stopStream()
 
+    await this.waitResults()
+  }
+
+  private async waitResults(): Promise<void> {
     // Wait for active contexts to finish
     if (this.activeContexts > 0) {
       const p = new Promise(resolve => {
@@ -260,7 +261,7 @@ export class CloudDecoder {
     }
     const contextId = await this.apiClient.stopContext()
     this.setState(DecoderState.Connected)
-    return contextId;
+    return contextId
   }
 
   /**
@@ -312,8 +313,10 @@ export class CloudDecoder {
       case WorkerSignal.VadSignalLow:
         this.cbs.forEach(cb => cb.onVadStateChange.forEach(f => f(false)))
         break
-      case WebsocketResponseType.Started: {
+      case WorkerSignal.RequestContextStart:
         this.activeContexts++
+        break
+      case WebsocketResponseType.Started: {
         const params = response.params
         this.audioContexts.set(response.audio_context, {
           segments: new Map(),

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -297,10 +297,10 @@ export interface ContextOptions {
  * Error to be thrown when BrowserClient is already started
  * @public
  */
- export const ErrAlreadyStarted = new Error('BrowserClient already started')
+export const ErrAlreadyStarted = new Error('BrowserClient already started')
 
- /**
+/**
  * Error to be thrown when BrowserClient is already stopped
  * @public
  */
-  export const ErrAlreadyStopped = new Error('BrowserClient already stopped')
+export const ErrAlreadyStopped = new Error('BrowserClient already stopped')

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -292,3 +292,15 @@ export interface ContextOptions {
    */
   nonStreamingNlu?: boolean
 }
+
+/**
+ * Error to be thrown when BrowserClient is already started
+ * @public
+ */
+ export const ErrAlreadyStarted = new Error('BrowserClient already started')
+
+ /**
+ * Error to be thrown when BrowserClient is already stopped
+ * @public
+ */
+  export const ErrAlreadyStopped = new Error('BrowserClient already stopped')

--- a/libraries/browser-client/src/microphone/browser_microphone.ts
+++ b/libraries/browser-client/src/microphone/browser_microphone.ts
@@ -1,5 +1,5 @@
 import { ErrDeviceNotSupported, DefaultSampleRate } from '../speechly'
-import { AudioSourceState, ErrNoAudioConsent, ErrNotInitialized } from './types'
+import { AudioSourceState, ErrNoAudioConsent } from './types'
 
 /**
  * Gets browser based microphone using the window.navigator.mediaDevices interface.
@@ -98,9 +98,7 @@ export class BrowserMicrophone {
    * Closes the microphone, releases all resources and stops the Speechly client.
    */
   async close(): Promise<void> {
-    if (!this.initialized) {
-      throw ErrNotInitialized
-    }
+    if (!this.initialized) return
 
     this.muted = true
 

--- a/libraries/browser-client/src/websocket/types.ts
+++ b/libraries/browser-client/src/websocket/types.ts
@@ -62,6 +62,7 @@ export enum WorkerSignal {
   AudioProcessorReady = 'SOURCE_SAMPLE_RATE_SET_SUCCESS',
   VadSignalHigh = 'VadSignalHigh',
   VadSignalLow = 'VadSignalLow',
+  RequestContextStart = 'RequestContextStart',
 }
 
 /**

--- a/libraries/browser-client/src/websocket/worker.test.ts
+++ b/libraries/browser-client/src/websocket/worker.test.ts
@@ -1,6 +1,8 @@
 import { ContextOptions } from '../client'
 import WebsocketClient, { contextOptionsToMsg } from './worker'
 
+const workerCtx = { postMessage: () => {} }
+
 describe('worker', () => {
   describe('contextOptionsToMsg', () => {
     test('default timezone', async () => {
@@ -25,8 +27,7 @@ describe('worker', () => {
   describe('setContextOptions', () => {
     jest.mock('./worker')
     test('no options', async () => {
-      // @ts-ignore
-      const worker = new WebsocketClient(undefined)
+      const worker = new WebsocketClient(workerCtx as any)
       worker.initAudioProcessor(16000, 30, 5)
       const mockSend = jest.spyOn(worker, 'send').mockImplementation()
       worker.startContext()
@@ -34,7 +35,7 @@ describe('worker', () => {
     })
     test('startContext with options', async () => {
       // @ts-ignore
-      const worker = new WebsocketClient(undefined)
+      const worker = new WebsocketClient(workerCtx as any)
       worker.initAudioProcessor(16000, 30, 5)
       const mockSend = jest.spyOn(worker, 'send').mockImplementation()
       const options: ContextOptions = { timezone: ['TZ'], vocabulary: ['W'] }
@@ -43,7 +44,7 @@ describe('worker', () => {
     })
     test('default options', async () => {
       // @ts-ignore
-      const worker = new WebsocketClient(undefined)
+      const worker = new WebsocketClient(workerCtx as any)
       worker.initAudioProcessor(16000, 30, 5)
       const mockSend = jest.spyOn(worker, 'send').mockImplementation()
       worker.setContextOptions({ vocabularyBias: ['0.2'], timezone: ['DEF_TZ'] })
@@ -54,7 +55,7 @@ describe('worker', () => {
     })
     test('default options + startContext with options', async () => {
       // @ts-ignore
-      const worker = new WebsocketClient(undefined)
+      const worker = new WebsocketClient(workerCtx as any)
       worker.initAudioProcessor(16000, 30, 5)
       const mockSend = jest.spyOn(worker, 'send').mockImplementation()
       worker.setContextOptions({ vocabularyBias: ['0.2'], timezone: ['DEF_TZ'] })

--- a/libraries/react-client/docs/classes/context.SpeechProvider.md
+++ b/libraries/react-client/docs/classes/context.SpeechProvider.md
@@ -99,11 +99,11 @@ ___
 
 ### stop
 
-▸ `Readonly` **stop**(): `Promise`<`void`\>
+▸ `Readonly` **stop**(): `Promise`<`string`\>
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`<`string`\>
 
 ___
 

--- a/libraries/react-client/docs/interfaces/context.SpeechContextState.md
+++ b/libraries/react-client/docs/interfaces/context.SpeechContextState.md
@@ -72,7 +72,7 @@ ___
 
 ▸ **start**(): `Promise`<`string`\>
 
-Turns listening on. Automatically initialises the API connection and audio stack.
+Turns listening on. Automatically initialises the API connection and audio stack. Returns the context id for the stated utterance.
 
 #### Returns
 
@@ -82,13 +82,13 @@ ___
 
 ### stop
 
-▸ **stop**(): `Promise`<`void`\>
+▸ **stop**(): `Promise`<`string`\>
 
-Turns listening off.
+Turns listening off. Returns the context id for the stopped utterance.
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`<`string`\>
 
 ## Properties
 

--- a/libraries/react-client/src/context.tsx
+++ b/libraries/react-client/src/context.tsx
@@ -48,7 +48,7 @@ export interface SpeechContextState {
   /**
    * Turns listening off.
    */
-  stop: () => Promise<void>
+  stop: () => Promise<string>
 
   /**
    * Current appId in multi-app project.
@@ -127,7 +127,7 @@ export const SpeechContext = React.createContext<SpeechContextState>({
   connect: async () => Promise.resolve(),
   attachMicrophone: async () => Promise.resolve(),
   start: async () => Promise.resolve('Unknown contextId'),
-  stop: async () => Promise.resolve(),
+  stop: async () => Promise.resolve('Unknown contextId'),
   clientState: DecoderState.Disconnected,
   microphoneState: AudioSourceState.Stopped,
   listening: false,
@@ -235,7 +235,7 @@ export class SpeechProvider extends React.Component<SpeechProviderProps, SpeechP
     return client.start()
   }
 
-  readonly stop = async (): Promise<void> => {
+  readonly stop = async (): Promise<string> => {
     const { client } = this.state
     this.setState({ listening: false })
     if (client == null) {

--- a/libraries/react-client/src/context.tsx
+++ b/libraries/react-client/src/context.tsx
@@ -41,12 +41,12 @@ export interface SpeechContextState {
   attachMicrophone: () => Promise<void>
 
   /**
-   * Turns listening on. Automatically initialises the API connection and audio stack.
+   * Turns listening on. Automatically initialises the API connection and audio stack. Returns the context id for the stated utterance.
    */
   start: () => Promise<string>
 
   /**
-   * Turns listening off.
+   * Turns listening off. Returns the context id for the stopped utterance.
    */
   stop: () => Promise<string>
 


### PR DESCRIPTION
### What

*Problem*: Calling `BrowserClient.start()` and `stop()` quickly multiple times resulted in `[Decoder] Unable to complete startContext: Expected Connected state, but was in Active` error.

- *Cause 1*: `BrowserClient.StopStream()` and `CloudDecoder.stopStream()` were operating outside their area of responsibilities and directly manipulated context active state. This is supposed to be the responsibility of `BrowserClient.Stop()` which has an action queue to protect against concurrent use and rapid state changes.

- *Cause 2*: `CloudDecoder.stopContext()` did not wait for the network request to complete.

Both of the causes contributed to `CloudDecoder.state` not being in sync with what was expected by concurrency-protected blocks in `BrowserClient.start()` and `CloudDecoder.stop()`.

- *Fixes*: 1) `BrowserClient.stopStream()` and `CloudDecoder.stopStream()` are no longer manipulating the context active state. 2) `CloudDecoder.stopContext()` waits for the network request to complete.

The problematic code was in place to ensure `BrowserClient.uploadAudioFile()` would end processing properly. To ensure reliable functioning, the following other changes were made:

- Ensured AudioProcessor.eos() (formerly flush) is called on stopStream (and not stopContext).
- Backported changes from C++ AudioProcessor to JS AudioProcessor with correct EOS handling.
- RequestContextStart WorkerSignal to count active contexts accurately.
- stopContext returns the contextId of the stopped context

### Why

BrowserClient should work reliably when stress-tested.
