### PR TITLE
Enhancement/close mic on stop

### DIFF
--- a/common/changes/@speechly/browser-client/enhancement-close-mic-on-stop_2022-10-17-08-54.json
+++ b/common/changes/@speechly/browser-client/enhancement-close-mic-on-stop_2022-10-17-08-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "A BrowserMicrophone instance can be passed to BrowserClient options in constructor. This enables automatic microphone initialization/attaching on BrowserClient.start() without need to call Microphone.initialize() manually. `closeMicrophone: true` can be passed to BrowserClient options to detach the microphone after each utterance and turn off the red recording dot in the browser interface.\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/common/changes/@speechly/browser-ui/enhancement-close-mic-on-stop_2022-10-18-10-57.json
+++ b/common/changes/@speechly/browser-ui/enhancement-close-mic-on-stop_2022-10-18-10-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "push-to-talk-button attaches microphone by BrowserMicrophone instance instead of MediaStream to enable closing and reopening. intro-popup fix to prevent re-displaying on mic reopen.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/common/changes/@speechly/browser-ui/enhancement-close-mic-on-stop_2022-10-19-09-48.json
+++ b/common/changes/@speechly/browser-ui/enhancement-close-mic-on-stop_2022-10-19-09-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "Added closemicrophone=\"true\" attribute.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/common/changes/@speechly/react-client/enhancement-close-mic-on-stop_2022-10-18-12-30.json
+++ b/common/changes/@speechly/react-client/enhancement-close-mic-on-stop_2022-10-18-12-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-client",
+      "comment": "react-client attaches microphone by BrowserMicrophone instance instead of MediaStream.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-client"
+}

--- a/common/changes/@speechly/react-client/enhancement-close-mic-on-stop_2022-10-19-09-48.json
+++ b/common/changes/@speechly/react-client/enhancement-close-mic-on-stop_2022-10-19-09-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-client",
+      "comment": "Microphone will be attached upon start.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@speechly/react-client"
+}

--- a/examples/browser-client-example/public/index.html
+++ b/examples/browser-client-example/public/index.html
@@ -24,11 +24,10 @@
 
     <div>
       <h3 id="status">Disconnected</h3>
-      <button id="connect">Connect</button>
-      <button id="initialize">Initialize</button>
+      <button id="connect">Initialize Client</button>
+      <button id="initialize">Initialize Mic</button>
       <button id="record">Hold to talk</button>
       <button id="upload">Upload file</button>
-      <button id="close">Close clients</button>
       <input type="checkbox" id="vad">Use VAD</input>
 
       <input type="file" id="fileElem" style="display:none">

--- a/examples/browser-client-example/src/index.ts
+++ b/examples/browser-client-example/src/index.ts
@@ -34,7 +34,8 @@ window.onload = () => {
     logSegments: false,
     connect: false,
     vad: { enabled: false, noiseGateDb: -24.0, signalSustainMillis: 2000 },
-    // microphone: mic,
+    closeMicrophone: false,
+    microphone: mic,
     ...process.env.REACT_APP_API_URL ? { apiUrl: process.env.REACT_APP_API_URL } : null,
 };
 

--- a/examples/react-client-example/src/App.js
+++ b/examples/react-client-example/src/App.js
@@ -36,7 +36,7 @@ function SpeechlyApp() {
         <button onClick={connect} disabled={clientState !== DecoderState.Disconnected}>Connect</button>
         <button onClick={attachMicrophone} disabled={microphoneState !== AudioSourceState.Stopped}>Initialize mic</button>
         <button onMouseDown={start} onMouseUp={stop}>
-          { listening ? 'Listening...' : 'Hold to listen' }
+          { listening ? 'Listening...' : 'Hold to talk' }
         </button>
       </div>
       <h3>Transcript</h3>

--- a/examples/react-client-example/src/App.js
+++ b/examples/react-client-example/src/App.js
@@ -9,7 +9,7 @@ export default function App() {
 
   return (
     <div className="App">
-      <SpeechProvider appId={appId}>
+      <SpeechProvider appId={appId} closeMicrophone={false} vad={{enabled: true}}>
         <SpeechlyApp/>
       </SpeechProvider>
     </div>

--- a/examples/react-ui-example/src/App.tsx
+++ b/examples/react-ui-example/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
 
   return (
     <div className="App">
-      <SpeechProvider appId={appId} >
+      <SpeechProvider appId={appId} closeMicrophone={false} >
         <SpeechlyApp />
       </SpeechProvider>
     </div>

--- a/libraries/browser-client/README.md
+++ b/libraries/browser-client/README.md
@@ -112,14 +112,15 @@ Please use a HTML server to view the example. Running it as a file will not work
 
       const widget = document.getElementById("textBox")
 
-      // Create a Speechly client instance.
+      // Create a Speechly client instance and microphone
       // NOTE: Configure and get your appId from https://api.speechly.com/dashboard
       const speechly = new BrowserClient({
         appId: "your-app-id",
         debug: true,
         logSegments: true,
+        microphone: new BrowserMicrophone(),
+        closeMicrophone: true,
       })
-      const microphone = new BrowserMicrophone()
 
       speechly.onSegmentChange(segment => {
         // Clean up and concatenate words
@@ -132,17 +133,11 @@ Please use a HTML server to view the example. Running it as a file will not work
       });
 
       const startListening = async () => {
-        if (microphone.mediaStream === undefined) {
-          await microphone.initialize()
-          await speechly.attach(microphone.mediaStream)
-        }
-        return speechly.start();
+        await speechly.start();
       }
 
       const stopListening = async () => {
-        if (speechly.isActive()) {
-          return speechly.stop();
-        }
+        await speechly.stop();
       }
 
       // Bind start listening to a widget hold, release anywhere to stop

--- a/libraries/browser-client/docs/classes/client.BrowserClient.md
+++ b/libraries/browser-client/docs/classes/client.BrowserClient.md
@@ -65,17 +65,10 @@ Create a new BrowserClient instance.
 
 ### initialize
 
-▸ **initialize**(`options?`): `Promise`<`void`\>
+▸ **initialize**(): `Promise`<`void`\>
 
 Connect to cloud, create an AudioContext for receiving audio samples from a MediaStream
 and initialize a worker for audio processing and bi-directional streaming to the cloud.
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `options?` | `Object` |
-| `options.mediaStream?` | `MediaStream` |
 
 #### Returns
 
@@ -85,9 +78,9 @@ ___
 
 ### attach
 
-▸ **attach**(`mediaStream`): `Promise`<`void`\>
+▸ **attach**(`audioSource?`): `Promise`<`void`\>
 
-Attach a MediaStream to the client, enabling the client to send the audio to the
+Attach a BrowserMicrophone or a MediaStream to the client, enabling the client to send the audio to the
 Speechly API for processing. The processing is activated by calling
 [BrowserClient.start](client.BrowserClient.md#start) and deactivated by calling [BrowserClient.stop](client.BrowserClient.md#stop).
 
@@ -95,7 +88,7 @@ Speechly API for processing. The processing is activated by calling
 
 | Name | Type |
 | :------ | :------ |
-| `mediaStream` | `MediaStream` |
+| `audioSource?` | `MediaStream` \| [`BrowserMicrophone`](microphone.BrowserMicrophone.md) |
 
 #### Returns
 

--- a/libraries/browser-client/docs/interfaces/client.DecoderOptions.md
+++ b/libraries/browser-client/docs/interfaces/client.DecoderOptions.md
@@ -29,6 +29,9 @@ The options which can be used to configure the client.
 - [storage](client.DecoderOptions.md#storage)
 - [frameMillis](client.DecoderOptions.md#framemillis)
 - [historyFrames](client.DecoderOptions.md#historyframes)
+- [mediaStream](client.DecoderOptions.md#mediastream)
+- [microphone](client.DecoderOptions.md#microphone)
+- [closeMicrophone](client.DecoderOptions.md#closemicrophone)
 
 ## Properties
 
@@ -183,3 +186,39 @@ Number of history frames to keep in ringbuffer. They are sent upon start of cont
 #### Inherited from
 
 Partial.historyFrames
+
+___
+
+### mediaStream
+
+• `Optional` **mediaStream**: `MediaStream`
+
+MediaStream instance to be used with BrowserClient. Only mediaStream or microphone can be used at a time.
+
+#### Inherited from
+
+Partial.mediaStream
+
+___
+
+### microphone
+
+• `Optional` **microphone**: [`BrowserMicrophone`](../classes/microphone.BrowserMicrophone.md)
+
+BrowserMicrophone instance to be used with BrowserClient. Only mediaStream or microphone can be used at a time.
+
+#### Inherited from
+
+Partial.microphone
+
+___
+
+### closeMicrophone
+
+• `Optional` **closeMicrophone**: `boolean`
+
+Controls whether or not microphone should be automatically detached and closed on stop and re-attached on start. MediaStreams cannot be automatically detached.
+
+#### Inherited from
+
+Partial.closeMicrophone

--- a/libraries/browser-client/docs/modules/client.md
+++ b/libraries/browser-client/docs/modules/client.md
@@ -67,6 +67,7 @@ Converts client state value to a string, which could be useful for debugging or 
 | `logSegments` | `boolean` |
 | `frameMillis` | `number` |
 | `historyFrames` | `number` |
+| `closeMicrophone` | `boolean` |
 
 ___
 

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -215,7 +215,7 @@ export class BrowserClient {
     } else if (audioSource instanceof MediaStream) {
       this.decoderOptions.mediaStream = audioSource
     }
-    
+
     await this._attach()
 
     // Auto-start stream if VAD is enabled
@@ -235,7 +235,7 @@ export class BrowserClient {
       } else if (this.decoderOptions.mediaStream) {
         this.stream = this.audioContext?.createMediaStreamSource(this.decoderOptions.mediaStream)
       } else {
-        throw Error("No MediaSteam or BrowserMicrophone to attach. Pass one to attach() or define it in constructor options.")
+        throw Error('No MediaSteam or BrowserMicrophone to attach. Pass one to attach() or define it in constructor options.')
       }
 
       // ensure audioContext is active

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -1,7 +1,6 @@
 import { DecoderState, EventCallbacks, DecoderOptions, ContextOptions, VadDefaultOptions, AudioProcessorParameters, StreamOptions, StreamDefaultOptions, DecoderDefaultOptions, ResolvedDecoderOptions, VadOptions, ErrAlreadyStarted, ErrAlreadyStopped } from './types'
 import { CloudDecoder } from './decoder'
 import { ErrDeviceNotSupported, DefaultSampleRate, Segment, Word, Entity, Intent } from '../speechly'
-import { BrowserMicrophone } from '../microphone/browser_microphone'
 
 import audioworklet from '../microphone/audioworklet'
 

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -206,15 +206,16 @@ export class BrowserClient {
    * Speechly API for processing. The processing is activated by calling
    * {@link BrowserClient.start} and deactivated by calling {@link BrowserClient.stop}.
    */
-  async attach(audioSource: MediaStream | BrowserMicrophone): Promise<void> {
+  async attach(audioSource?: MediaStream | BrowserMicrophone): Promise<void> {
     await this.initialize()
     await this.detach()
 
     if (audioSource instanceof BrowserMicrophone) {
       this.decoderOptions.microphone = audioSource
-    } else {
+    } else if (audioSource instanceof MediaStream) {
       this.decoderOptions.mediaStream = audioSource
     }
+    
     await this._attach()
 
     // Auto-start stream if VAD is enabled
@@ -231,10 +232,10 @@ export class BrowserClient {
         if (this.decoderOptions.microphone.mediaStream) {
           this.stream = this.audioContext?.createMediaStreamSource(this.decoderOptions.microphone.mediaStream)
         }
-      }
-
-      if (this.decoderOptions.mediaStream) {
+      } else if (this.decoderOptions.mediaStream) {
         this.stream = this.audioContext?.createMediaStreamSource(this.decoderOptions.mediaStream)
+      } else {
+        throw Error("No MediaSteam or BrowserMicrophone to attach. Pass one to attach() or define it in constructor options.")
       }
 
       // ensure audioContext is active

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -36,7 +36,6 @@ export class BrowserClient {
   private active: boolean = false
   private speechlyNode?: AudioWorkletNode
   private audioProcessor?: ScriptProcessorNode
-  private readonly browserMicrophone?: BrowserMicrophone
   private stream?: MediaStreamAudioSourceNode
   private listeningPromise: Promise<any> | null = null
   private readonly decoderOptions: ResolvedDecoderOptions & { vad?: VadOptions }
@@ -254,7 +253,7 @@ export class BrowserClient {
 
     const contextId = await this.queueTask(async () => {
       await this.initialize()
-      // Re-establish microphone input
+      // Re-attach microphone if detached
       if (this.decoderOptions.microphone && !this.stream) {
         await this.decoderOptions.microphone.initialize()
         if (this.decoderOptions.microphone.mediaStream) {

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -70,12 +70,17 @@ export interface ResolvedDecoderOptions {
   historyFrames: number
 
   /**
-   * BrowserMicrophone instance to be used with BrowserClient.
+   * MediaStream instance to be used with BrowserClient. Only mediaStream or microphone can be used at a time.
+   */
+  mediaStream?: MediaStream
+
+  /**
+   * BrowserMicrophone instance to be used with BrowserClient. Only mediaStream or microphone can be used at a time.
    */
   microphone?: BrowserMicrophone
 
   /**
-   * Controls whether or not microphone should be closed on stop
+   * Controls whether or not microphone should be automatically detached and closed on stop and re-attached on start. MediaStreams cannot be automatically detached.
    */
   closeMicrophone?: boolean
 }

--- a/libraries/browser-client/src/client/types.ts
+++ b/libraries/browser-client/src/client/types.ts
@@ -1,3 +1,4 @@
+import { BrowserMicrophone } from '../microphone'
 import { Segment, Word, Entity, Intent, DefaultSampleRate } from '../speechly'
 import { Storage } from '../storage'
 import { CloudDecoder } from './decoder'
@@ -67,6 +68,16 @@ export interface ResolvedDecoderOptions {
    * Number of history frames to keep in ringbuffer. They are sent upon start of context to capture the start of utterance, which is especially important to compensate loss of utterance start with VAD.
    */
   historyFrames: number
+
+  /**
+   * BrowserMicrophone instance to be used with BrowserClient.
+   */
+  microphone?: BrowserMicrophone
+
+  /**
+   * Controls whether or not microphone should be closed on stop
+   */
+  closeMicrophone?: boolean
 }
 
 /**
@@ -88,6 +99,7 @@ export const DecoderDefaultOptions = {
   logSegments: false,
   frameMillis: 30,
   historyFrames: 5,
+  closeMicrophone: false,
 }
 
 /**

--- a/libraries/browser-client/src/microphone/browser_microphone.ts
+++ b/libraries/browser-client/src/microphone/browser_microphone.ts
@@ -47,6 +47,7 @@ export class BrowserMicrophone {
     if (this.initialized) {
       return
     }
+    this.initialized = true
 
     // ensure mediaDevices are available
     if (window.navigator?.mediaDevices === undefined) {
@@ -76,7 +77,6 @@ export class BrowserMicrophone {
       throw ErrNoAudioConsent
     }
 
-    this.initialized = true
     this.muted = true
     this.setState(AudioSourceState.Started)
   }

--- a/libraries/browser-ui/src/assets/index.html
+++ b/libraries/browser-ui/src/assets/index.html
@@ -85,6 +85,7 @@
         <li><code>capturekey</code> - Optional string (of length 1). Defines a keyboard hotkey that with control listening on/off. Default: undefined. Recommendation: Space (" ")</li>
         <li><code>poweron</code> - Optional string "auto"|"true"|"false". If "true", first button press sends a "poweron" message instead of initializing Speechly. This allows displaying a welcome screen using Intro Popup or a custom implementation. "auto" setting tries to detect presence of Intro Popup in DOM and use poweron if found. Default: "auto" </li>
         <li><code>hide</code> - Optional "false" | "true". Default: "false"</li>
+        <li><code>closemicrophone</code> - Optional "false" | "true". Set to true to close microphone after listening ends. May introduce input lag on older browsers. Default: "false".</li>
       </ul>
       <h3>Attributes for styling</h3>
       <ul>       

--- a/libraries/browser-ui/src/intro-popup.svelte
+++ b/libraries/browser-ui/src/intro-popup.svelte
@@ -132,7 +132,7 @@
               visibility = true;
             }
           }, 500);
-        } else {
+        } else if (firstConnect) {
           visibility = true;
         }
         break;

--- a/libraries/browser-ui/src/push-to-talk-button.svelte
+++ b/libraries/browser-ui/src/push-to-talk-button.svelte
@@ -90,7 +90,7 @@
       introPopup = el;
       el.addEventListener(MessageType.requeststartmicrophone, async() => {
         await microphone.initialize()
-        await client.attach(microphone.mediaStream)
+        await client.attach(microphone)
       });
       usePermissionPriming = localStorage.getItem(LocalStorageKeys.SpeechlyFirstConnect) === null;
     }
@@ -100,6 +100,7 @@
     if (mounted && !client && (projectid || appid)) {
       const clientOptions = {
         connect: false,
+        // closeMicrophone: true,
         ...(appid && !projectid && {appId: appid}),
         ...(projectid && {projectId: projectid}),
         ...(apiurl && {apiUrl: apiurl}),
@@ -147,8 +148,8 @@
             // Make sure you call `initialize` from a user action handler (e.g. from a button press handler).
             try {
               const initStartTime = Date.now();
-              await microphone.initialize()
-              await client.attach(microphone.mediaStream)
+              await microphone.initialize();
+              await client.attach(microphone);
               // Long init time suggests permission dialog --> prevent listening start
               holdListenActive = Date.now() - initStartTime < PERMISSION_PRE_GRANTED_TRESHOLD_MS;
             } catch (e) {

--- a/libraries/react-client/README.md
+++ b/libraries/react-client/README.md
@@ -69,14 +69,16 @@ export default function App() {
 }
 
 function SpeechlyApp() {
-  const { listening, segment, toggleRecording } = useSpeechContext()
+  const { listening, segment, start, stop } = useSpeechContext()
 
   return (
     <div>
       <div className="status">Listening: {listening}</div>
       {segment ? <div className="segment">{segment.words.map(w => w.value).join(' ')}</div> : null}
       <div className="mic-button">
-        <button onClick={toggleRecording}>Record</button>
+        <button onMouseDown={start} onMouseUp={stop}>
+          { listening ? 'Listening...' : 'Hold to talk' }
+        </button>
       </div>
     </div>
   )

--- a/libraries/react-client/docs/interfaces/context.SpeechContextState.md
+++ b/libraries/react-client/docs/interfaces/context.SpeechContextState.md
@@ -34,7 +34,6 @@ Individual values (transcripts, entities and intent) are reset back to undefined
 - [intent](context.SpeechContextState.md#intent)
 - [segment](context.SpeechContextState.md#segment)
 - [client](context.SpeechContextState.md#client)
-- [microphone](context.SpeechContextState.md#microphone)
 
 ## Methods
 
@@ -188,11 +187,3 @@ ___
 • `Optional` **client**: `BrowserClient`
 
 Low-level access to underlying Speechly BrowserClient.
-
-___
-
-### microphone
-
-• `Optional` **microphone**: `BrowserMicrophone`
-
-Low-level access to underlying Speechly BrowserMicrophone.

--- a/libraries/react-client/docs/interfaces/context.SpeechProviderProps.md
+++ b/libraries/react-client/docs/interfaces/context.SpeechProviderProps.md
@@ -31,6 +31,9 @@ Props for SpeechContext provider, which are used to initialise API client.
 - [storage](context.SpeechProviderProps.md#storage)
 - [frameMillis](context.SpeechProviderProps.md#framemillis)
 - [historyFrames](context.SpeechProviderProps.md#historyframes)
+- [mediaStream](context.SpeechProviderProps.md#mediastream)
+- [microphone](context.SpeechProviderProps.md#microphone)
+- [closeMicrophone](context.SpeechProviderProps.md#closemicrophone)
 
 ## Properties
 
@@ -203,3 +206,39 @@ Number of history frames to keep in ringbuffer. They are sent upon start of cont
 #### Inherited from
 
 DecoderOptions.historyFrames
+
+___
+
+### mediaStream
+
+• `Optional` **mediaStream**: `MediaStream`
+
+MediaStream instance to be used with BrowserClient. Only mediaStream or microphone can be used at a time.
+
+#### Inherited from
+
+DecoderOptions.mediaStream
+
+___
+
+### microphone
+
+• `Optional` **microphone**: `BrowserMicrophone`
+
+BrowserMicrophone instance to be used with BrowserClient. Only mediaStream or microphone can be used at a time.
+
+#### Inherited from
+
+DecoderOptions.microphone
+
+___
+
+### closeMicrophone
+
+• `Optional` **closeMicrophone**: `boolean`
+
+Controls whether or not microphone should be automatically detached and closed on stop and re-attached on start. MediaStreams cannot be automatically detached.
+
+#### Inherited from
+
+DecoderOptions.closeMicrophone

--- a/libraries/react-client/src/context.tsx
+++ b/libraries/react-client/src/context.tsx
@@ -204,19 +204,14 @@ export class SpeechProvider extends React.Component<SpeechProviderProps, SpeechP
     }
 
     const microphone = new BrowserMicrophone()
+
     microphone.onStateChange((state: AudioSourceState) => {
       this.setState({
         microphoneState: state,
       })
     })
 
-    await microphone.initialize()
-
-    if (microphone.mediaStream) {
-      await client.attach(microphone.mediaStream)
-    } else {
-      throw Error('Microphone contains no MediaStream to attach')
-    }
+    await client.attach(microphone)
 
     this.setState({
       microphone: microphone,


### PR DESCRIPTION
### browser-client changes

- `BrowserMicrophone` or `MediaStream` instance can be passed to BrowserClient options in constructor.
- `BrowserMicrophone` or `MediaStream` instance or can be passed to `BrowserClient.attach()`. It can also be called without parameters to initialize and attach the audio source passed in the constructor.
- `closeMicrophone: true` can be passed to BrowserClient options to detach and reattach the microphone after each utterance. This works well for modern browsers, but lag is introduced with legacy browsers like iOS 12 Safari. Thus the default setting is `false`.

### browser-ui, react-client and react-ui

- browser-ui's `push-to-talk-button` component accepts `closemicrophone="true"` attribute.
- react-client (and thus react-ui) accept `closeMicrophone={true}` property.

### Why

- With `closeMicrophone: true` the "red microphone dot" is removed from the browser interface to better communicate when the app is listening.
- With microphone given with constructor options, automatic microphone initialization/attaching works again by calling `BrowserClient.start()`. This makes `attach()` an optional initialization step. It is, however, useful if one wants to do mic initialization/permissions before starting to listen.
