### PR TITLE
Fix/connection drop recovery

### DIFF
--- a/common/changes/@speechly/browser-client/fix-connection-drop-recovery_2022-11-22-12-45.json
+++ b/common/changes/@speechly/browser-client/fix-connection-drop-recovery_2022-11-22-12-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "BrowserClient.initialize() immediately throws a sane error and sets the client to FAILED state if called offline. User-initiated BrowserClient.close() is performed immediately, without waiting for backend to acknowledge. This eliminates confusing errors when called offline. Fixed resuming listening after offline call to BrowserClient.close(). Added an already stopped check to BrowserClient.stopStream() to prevent confusing downstream errors.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/common/changes/@speechly/browser-ui/fix-connection-drop-recovery_2022-12-13-10-28.json
+++ b/common/changes/@speechly/browser-ui/fix-connection-drop-recovery_2022-12-13-10-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-ui",
+      "comment": "Improved recovery after connection loss.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-ui"
+}

--- a/common/changes/@speechly/react-client/fix-connection-drop-recovery_2022-12-14-11-50.json
+++ b/common/changes/@speechly/react-client/fix-connection-drop-recovery_2022-12-14-11-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-client",
+      "comment": "Improved recovery after connection loss. Improved behaviour with React 18 mount, unmount, mount upon app start.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-client"
+}

--- a/examples/browser-client-example/src/index.ts
+++ b/examples/browser-client-example/src/index.ts
@@ -83,7 +83,7 @@ window.onload = () => {
     const connectButton = document.getElementById("connect") as HTMLButtonElement;
     const statusDiv = document.getElementById("status") as HTMLButtonElement;
     connectButton.innerHTML =
-      state === DecoderState.Disconnected ? "Connect" : "Disconnect";
+      state <= DecoderState.Disconnected ? "Connect" : "Disconnect";
     statusDiv.innerHTML = stateToString(state);
     decoderState = state
   });
@@ -219,12 +219,8 @@ function bindListenButton(bc: BrowserClient) {
 
 function bindConnectButton(bc: BrowserClient) {
   const connect = async (event: MouseEvent | TouchEvent) => {
-    if (decoderState === DecoderState.Disconnected) {
-      try {
-        await bc.initialize();
-      } catch (err) {
-        console.error("Error connecting Speechly:", err);
-      }
+    if (decoderState <= DecoderState.Disconnected) {
+      await bc.initialize();
     } else {
       await bc.close();
     }

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -428,8 +428,10 @@ export class BrowserClient {
    * Use `startStream` to resume audio processing afterwards.
    */
   async stopStream(): Promise<void> {
-    this.isStreaming = false
-    await this.decoder.stopStream()
+    if (this.isStreaming) {
+      this.isStreaming = false
+      await this.decoder.stopStream()
+    }
   }
 
   private async queueTask(task: () => Promise<any>): Promise<any> {
@@ -512,6 +514,7 @@ export class BrowserClient {
     }
     await this.decoder.close()
     this.initialized = false
+    this.listeningPromise = null
   }
 
   private async sleep(ms: number): Promise<void> {

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -92,6 +92,12 @@ export class BrowserClient {
     } catch (err) {
       this.initialized = false
       if (err instanceof WebsocketError) {
+        if (err.code === 1000) {
+          if (this.debug) {
+            console.log('[BrowserClient]', 'Early close of websocket.')
+          }
+          return
+        }
         throw Error(`Unable to connect. Most likely there is no connection to network. Websocket error code: ${err.code}`)
       } else {
         throw err
@@ -493,6 +499,7 @@ export class BrowserClient {
       case DecoderState.Failed:
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.stopStream()
+        this.active = false
         this.listeningPromise = null
         break
     }
@@ -516,6 +523,9 @@ export class BrowserClient {
    * processors.
    */
   async close(): Promise<void> {
+    if (this.debug) {
+      console.log('[BrowserClient]', 'close')
+    }
     await this.detach()
     if (this.speechlyNode !== null) {
       this.speechlyNode?.port.close()

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -86,7 +86,7 @@ export class BrowserClient {
     if (this.debug) {
       console.log('[BrowserClient]', 'initializing')
     }
-    await this.decoder.connect()
+
     try {
       const opts: AudioContextOptions = {}
       if (this.nativeResamplingSupported) {
@@ -199,6 +199,8 @@ export class BrowserClient {
     if (options?.mediaStream) {
       await this.attach(options?.mediaStream)
     }
+
+    await this.decoder.connect()
   }
 
   /**

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -493,6 +493,7 @@ export class BrowserClient {
       case DecoderState.Failed:
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.stopStream()
+        this.listeningPromise = null
         break
     }
   }

--- a/libraries/browser-client/src/client/browser_client.ts
+++ b/libraries/browser-client/src/client/browser_client.ts
@@ -211,7 +211,6 @@ export class BrowserClient {
     if (options?.mediaStream) {
       await this.attach(options?.mediaStream)
     }
-
   }
 
   /**

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -459,9 +459,8 @@ export class CloudDecoder {
   }
 
   private async reconnect(): Promise<void> {
-    if (this.debug) {
-      console.log('[Decoder]', 'Reconnecting...', this.connectAttempt)
-    }
+    console.log('Speechly reconnecting')
+
     this.connectPromise = null
     if (this.connectAttempt < this.maxReconnectAttemptCount) {
       await this.sleep(this.getReconnectDelayMs(this.connectAttempt++))

--- a/libraries/browser-client/src/client/decoder.ts
+++ b/libraries/browser-client/src/client/decoder.ts
@@ -137,7 +137,9 @@ export class CloudDecoder {
           await this.apiClient.initialize(this.apiUrl, this.authToken, this.sampleRate, this.debug)
         } catch (err) {
           this.connectPromise = null
-          this.setState(DecoderState.Failed)
+          if (!(err instanceof WebsocketError && err.code === 1000)) {
+            this.setState(DecoderState.Failed)
+          }
           throw err
         }
         this.advanceState(DecoderState.Connected)

--- a/libraries/browser-client/src/speechly/types.ts
+++ b/libraries/browser-client/src/speechly/types.ts
@@ -16,7 +16,7 @@ export class WebsocketError extends Error {
   code: number
   wasClean: boolean
 
-  constructor(reason: string, code = 1000, wasClean: true, ...params: any) {
+  constructor(reason: string, code: number, wasClean: boolean, ...params: any) {
     // Pass remaining arguments (including vendor specific ones) to parent constructor
     super(...params)
 

--- a/libraries/browser-client/src/speechly/types.ts
+++ b/libraries/browser-client/src/speechly/types.ts
@@ -12,6 +12,21 @@ export const ErrDeviceNotSupported = new Error('Current device does not support 
  */
 export const ErrAppIdChangeWithoutProjectLogin = new Error('AppId changed without project login')
 
+export class WebsocketError extends Error {
+  code: number
+  wasClean: boolean
+
+  constructor(reason: string, code = 1000, wasClean: true, ...params: any) {
+    // Pass remaining arguments (including vendor specific ones) to parent constructor
+    super(...params)
+
+    this.name = 'WebsocketError'
+    this.message = reason
+    this.code = code
+    this.wasClean = wasClean
+  }
+}
+
 /**
  * Default sample rate for microphone streams.
  * @public

--- a/libraries/browser-client/src/speechly/types.ts
+++ b/libraries/browser-client/src/speechly/types.ts
@@ -20,7 +20,7 @@ export class WebsocketError extends Error {
     // Pass remaining arguments (including vendor specific ones) to parent constructor
     super(...params)
 
-    this.name = 'WebsocketError'
+    this.name = `WebsocketError code ${code}`
     this.message = reason
     this.code = code
     this.wasClean = wasClean

--- a/libraries/browser-client/src/websocket/types.ts
+++ b/libraries/browser-client/src/websocket/types.ts
@@ -1,4 +1,5 @@
 import { AudioProcessorParameters, ContextOptions, StreamOptions, VadOptions } from '../client'
+import { WebsocketError } from '../speechly'
 
 /**
  * The interface for response returned by WebSocket client.
@@ -191,7 +192,7 @@ export type ResponseCallback = (response: WebsocketResponse) => void
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/member-delimiter-style
-export type CloseCallback = (err: { code: number; reason: string; wasClean: boolean }) => void
+export type CloseCallback = (err: WebsocketError) => void
 
 /**
  * The interface for a client for Speechly SLU WebSocket API.

--- a/libraries/browser-client/src/websocket/webWorkerController.ts
+++ b/libraries/browser-client/src/websocket/webWorkerController.ts
@@ -12,7 +12,7 @@ type ContextCallback = (err?: Error, contextId?: string) => void
 export class WebWorkerController implements APIClient {
   private readonly worker: Worker
   private onInitResolve?: () => void
-  private onInitReject?: ( result: WebsocketError ) => void
+  private onInitReject?: (result: WebsocketError) => void
   private resolveSourceSampleRateSet?: (value?: void) => void
 
   private startCbs: ContextCallback[] = []
@@ -55,7 +55,7 @@ export class WebWorkerController implements APIClient {
       this.onInitReject = (err: WebsocketError) => {
         this.onInitResolve = undefined
         this.onInitReject = undefined
-        reject(err)
+        reject(err) // Will throw WebsocketError in `await initialize()`
       }
     })
   }
@@ -166,7 +166,7 @@ export class WebWorkerController implements APIClient {
         }
         break
       case WorkerSignal.Closed:
-        let e = new WebsocketError(
+        const e = new WebsocketError(
           event.data.reason,
           event.data.code,
           event.data.wasClean,

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -226,7 +226,6 @@ class WebsocketClient {
   }
 
   closeWebsocket(code: number = 1005, reason: string = 'No Status Received', wasClean: boolean = true, userInitiated: boolean = true): void {
-
     if (!this.websocket) {
       console.warn('WebSocket already closed')
       return
@@ -254,7 +253,6 @@ class WebsocketClient {
       reason,
       wasClean,
     })
-
   }
 
   // WebSocket's close handler, called when encountering a non user-initiated close, e.g.

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -199,10 +199,8 @@ class WebsocketClient {
     this.audioProcessor.setSendAudio(false)
     this.isContextStarted = false
 
-    if (this.websocket) {
-      const StopEventJSON = JSON.stringify({ event: 'stop' })
-      this.send(StopEventJSON)
-    }
+    const StopEventJSON = JSON.stringify({ event: 'stop' })
+    this.send(StopEventJSON)
   }
 
   switchContext(contextOptions?: ContextOptions): void {
@@ -233,7 +231,8 @@ class WebsocketClient {
     }
 
     if (!this.websocket) {
-      throw Error('WebSocket is undefined')
+      console.warn('WebSocket already closed')
+      return
     }
 
     this.websocket.close(websocketCode, reason)
@@ -313,7 +312,8 @@ class WebsocketClient {
     }
 
     if (this.websocket.readyState !== this.websocket.OPEN) {
-      throw new Error(`Expected OPEN Websocket state, but got ${this.websocket.readyState}`)
+      console.warn(`Expected OPEN Websocket state, but got ${this.websocket.readyState}`)
+      return
     }
 
     try {

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -225,33 +225,21 @@ class WebsocketClient {
     this.send(JSON.stringify(message))
   }
 
-  closeWebsocket(websocketCode: number = 1005, reason: string = 'No Status Received'): void {
-    if (this.debug) {
-      console.log('[WebSocketClient]', 'Websocket closing')
-    }
+  closeWebsocket(code: number = 1005, reason: string = 'No Status Received', wasClean: boolean = true, userInitiated: boolean = true): void {
 
     if (!this.websocket) {
       console.warn('WebSocket already closed')
       return
-    }
-
-    this.websocket.close(websocketCode, reason)
-  }
-
-  // WebSocket's close handler, called e.g. when
-  // - normal close (code 1000)
-  // - network unreachable or unable to (re)connect (code 1006)
-  // List of CloseEvent.code values: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
-  private readonly onWebsocketClose = (event: CloseEvent): void => {
-    if (!this.websocket) {
-      throw Error('WebSocket is undefined')
+    } else if (this.debug) {
+      console.log('[WebSocketClient]', userInitiated ? 'Websocket close requested' : 'Websocket closed')
     }
 
     // Reset audioprocessor so it won't try to send audio the first thing when reconnect happens. This will lead to a reconnect loop.
     this.audioProcessor?.reset()
 
-    if (this.debug) {
-      console.log('[WebSocketClient]', 'onWebsocketClose')
+    // If we're here due to a call to onWebSocket
+    if (userInitiated) {
+      this.websocket.close(code, reason)
     }
 
     this.websocket.removeEventListener('open', this.onWebsocketOpen)
@@ -262,10 +250,22 @@ class WebsocketClient {
 
     this.workerCtx.postMessage({
       type: WorkerSignal.Closed,
-      code: event.code,
-      reason: event.reason,
-      wasClean: event.wasClean,
+      code,
+      reason,
+      wasClean,
     })
+
+  }
+
+  // WebSocket's close handler, called when encountering a non user-initiated close, e.g.
+  // - network unreachable or unable to (re)connect (code 1006)
+  // List of CloseEvent.code values: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code
+  private readonly onWebsocketClose = (event: CloseEvent): void => {
+    if (this.debug) {
+      console.log('[WebSocketClient]', 'onWebsocketClose')
+    }
+
+    this.closeWebsocket(event.code, event.reason, event.wasClean, false)
   }
 
   private readonly onWebsocketOpen = (_event: Event): void => {
@@ -346,7 +346,7 @@ ctx.onmessage = function (e) {
       websocketClient.setSharedArrayBuffers(e.data.controlSAB, e.data.dataSAB)
       break
     case ControllerSignal.CLOSE:
-      websocketClient.closeWebsocket(1000, 'Close requested by client')
+      websocketClient.closeWebsocket(1000, 'Close requested by client', true, true)
       break
     case ControllerSignal.startStream:
       websocketClient.startStream(e.data.streamOptions)

--- a/libraries/browser-client/src/websocket/worker.ts
+++ b/libraries/browser-client/src/websocket/worker.ts
@@ -236,15 +236,17 @@ class WebsocketClient {
     // Reset audioprocessor so it won't try to send audio the first thing when reconnect happens. This will lead to a reconnect loop.
     this.audioProcessor?.reset()
 
+    // We don't want any more messages from the closing websocket
+    this.websocket.removeEventListener('open', this.onWebsocketOpen)
+    this.websocket.removeEventListener('message', this.onWebsocketMessage)
+    this.websocket.removeEventListener('error', this.onWebsocketError)
+    this.websocket.removeEventListener('close', this.onWebsocketClose)
+
     // If we're here due to a call to onWebSocket
     if (userInitiated) {
       this.websocket.close(code, reason)
     }
 
-    this.websocket.removeEventListener('open', this.onWebsocketOpen)
-    this.websocket.removeEventListener('message', this.onWebsocketMessage)
-    this.websocket.removeEventListener('error', this.onWebsocketError)
-    this.websocket.removeEventListener('close', this.onWebsocketClose)
     this.websocket = undefined
 
     this.workerCtx.postMessage({

--- a/libraries/browser-ui/src/intro-popup.svelte
+++ b/libraries/browser-ui/src/intro-popup.svelte
@@ -11,7 +11,6 @@
   export let microphonestate: string = undefined;
   export let remsize = "1.0rem";
   export let position = "fixed";
-  export let appid = undefined;
   export let customcssurl = undefined;
   export let customtypography = undefined;
 
@@ -70,6 +69,7 @@
           visibility = true;
         }
         showAllowButton = true;
+        page = PagePriming
         break;
       case MessageType.speechstate:
         onClientStateChange(e.data.state)
@@ -82,13 +82,6 @@
           case AudioSourceState.NoAudioConsent:
           case AudioSourceState.NoBrowserSupport:
             showError(e.data.audioSourceState);
-            break;
-          default:
-            switch (e.data.state) {
-              case DecoderState.Failed:
-                showError(e.data.state);
-                break;
-            }
             break;
         }
         break;
@@ -234,11 +227,7 @@
       {:else}
         <h2>Failed to connect to Speechly</h2>
         <p>
-          {#if appid}
-            Please check that your application (App ID: {appid}) has been successfully deployed.
-          {:else}
-            Please check that your application has been successfully deployed.
-          {/if}
+          Please check your internet connection. If the problem persists, please try again later.
         </p>
         <options>
           <button on:click={closeSelf} class="button button-primary">Ok, got it</button>

--- a/libraries/browser-ui/src/push-to-talk-button.svelte
+++ b/libraries/browser-ui/src/push-to-talk-button.svelte
@@ -89,6 +89,7 @@
     if (introPopup === null && el !== null) {
       introPopup = el;
       el.addEventListener(MessageType.requeststartmicrophone, async() => {
+        await client.initialize()
         await microphone.initialize()
         await client.attach(microphone.mediaStream)
       });
@@ -147,13 +148,13 @@
             // Make sure you call `initialize` from a user action handler (e.g. from a button press handler).
             try {
               const initStartTime = Date.now();
+              await client.initialize()
               await microphone.initialize()
               await client.attach(microphone.mediaStream)
               // Long init time suggests permission dialog --> prevent listening start
               holdListenActive = Date.now() - initStartTime < PERMISSION_PRE_GRANTED_TRESHOLD_MS;
             } catch (e) {
-              console.error("Speechly initialization failed", e);
-              client = null;
+              console.error("Speechly initialization failed - ", e);
               holdListenActive = false;
             }
           } else {


### PR DESCRIPTION
### What

- `BrowserClient.initialize()` immediately throws a sane error and sets the client to FAILED state if called offline.
- User-initiated `BrowserClient.close()` now sets the client to closed state immediately (was: client was set to closed state after backend acknowledged the close frame). The change eliminates confusing errors like `Expected OPEN Websocket state, but got 2` when called offline.
- Fixed resuming listening after offline call to `BrowserClient.close()`.
- Added an already stopped check to `BrowserClient.stopStream()` to prevent confusing downstream errors.

### Why

- More graceful behaviour when websocket connection is dropped unexpectedly or timed out.

### Testing

Possible repro for `Expected OPEN Websocket state, but got 2` mentioned here:  https://github.com/speechly/speechly/discussions/244

Use browser-client-example:
- Connect
- Initialize
- Hold-to-talk, release
- Chrome > Dev tools > Network > Throttling: Offline
- Close
- Observe “Expected OPEN Websocket state, but got 2”
- Connect
- Observe “”[Decoder] Websocket closed due to error {code: 1006, reason: ‘’, wasClean: false}“”

