### PR TITLE
Demo/update demo navigation

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,7 +24,7 @@ specifiers:
   '@rush-temp/smart-home': file:./projects/smart-home.tgz
   '@rush-temp/speech-to-text': file:./projects/speech-to-text.tgz
   '@rush-temp/voice-search': file:./projects/voice-search.tgz
-  '@speechly/demo-navigation': ^0.1.37
+  '@speechly/demo-navigation': ^0.1.38
   '@testing-library/jest-dom': ^4.2.4
   '@testing-library/react': ^9.3.2
   '@testing-library/user-event': ^7.1.2
@@ -72,6 +72,7 @@ specifiers:
   react-openai-api: ^1.0.2
   react-refresh: ^0.9.0
   react-spring: ^9.4.4
+  react-usestateref: ^1.0.8
   rimraf: ^3.0.2
   rollup: ^2.63.0
   rollup-plugin-copy-watch: '>=0.0.1'
@@ -122,7 +123,7 @@ dependencies:
   '@rush-temp/smart-home': file:projects/smart-home.tgz_ts-node@10.9.1
   '@rush-temp/speech-to-text': file:projects/speech-to-text.tgz_ts-node@10.9.1
   '@rush-temp/voice-search': file:projects/voice-search.tgz_ts-node@10.9.1
-  '@speechly/demo-navigation': 0.1.37
+  '@speechly/demo-navigation': 0.1.38
   '@testing-library/jest-dom': 4.2.4
   '@testing-library/react': 9.5.0
   '@testing-library/user-event': 7.2.1
@@ -170,6 +171,7 @@ dependencies:
   react-openai-api: 1.0.2_axios@0.21.4
   react-refresh: 0.9.0
   react-spring: 9.5.5
+  react-usestateref: 1.0.8
   rimraf: 3.0.2
   rollup: 2.79.1
   rollup-plugin-copy-watch: 0.0.1
@@ -3246,21 +3248,8 @@ packages:
       '@sinonjs/commons': 1.8.5
     dev: false
 
-  /@speechly/demo-navigation/0.1.37:
-    resolution: {integrity: sha512-eS9og2qjWjO4RV7lGs0G5oqxR/wgUMLzmCoiAG9aamKrP6oygw3o5WuEZBjiL8/L+0KobpUtdnmF8z+eIDwjeA==}
-    peerDependencies:
-      react: '>=17.0.2'
-      react-dom: '>=17.0.2'
-    dev: false
-
-  /@speechly/demo-navigation/0.1.37_react-dom@18.2.0+react@18.2.0:
-    resolution: {integrity: sha512-eS9og2qjWjO4RV7lGs0G5oqxR/wgUMLzmCoiAG9aamKrP6oygw3o5WuEZBjiL8/L+0KobpUtdnmF8z+eIDwjeA==}
-    peerDependencies:
-      react: '>=17.0.2'
-      react-dom: '>=17.0.2'
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+  /@speechly/demo-navigation/0.1.38:
+    resolution: {integrity: sha512-k6/8QbOQ6U1qY6G93UUy3ii5kiUvEttl10kRK0MK0NSMu8r+RsSy6J2shUlLG9N8xl3w7+My8/pVXH/dMLNWHA==}
     dev: false
 
   /@surma/rollup-plugin-off-main-thread/1.4.2:
@@ -15358,6 +15347,12 @@ packages:
       - zdog
     dev: false
 
+  /react-usestateref/1.0.8:
+    resolution: {integrity: sha512-whaE6H0XGarFKwZ3EYbpHBsRRCLZqdochzg/C7e+b6VFMTA3LS3K4ZfpI4NT40iy83jG89rGXrw70P9iDfOdsA==}
+    peerDependencies:
+      react: '>16.0.0'
+    dev: false
+
   /react-usestateref/1.0.8_react@18.2.0:
     resolution: {integrity: sha512-whaE6H0XGarFKwZ3EYbpHBsRRCLZqdochzg/C7e+b6VFMTA3LS3K4ZfpI4NT40iy83jG89rGXrw70P9iDfOdsA==}
     peerDependencies:
@@ -19016,12 +19011,12 @@ packages:
     dev: false
 
   file:projects/analyzer.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-bLWALa7fooYRQ8XcgigOSydaWaiiEHI3+xhb/uR6/8dPmFj8gwqVK9WFE3jJNvTn7qdP5dW832eb84tw5rohfw==, tarball: file:projects/analyzer.tgz}
+    resolution: {integrity: sha512-9mv/f0h6pP6vpvwdyHfCk1uN6iQPW6CyFWcClnb8lJlOVA2HUA6dd05SZB36QfKbxVy7BUzDwaJ/CpmMfZMEAg==, tarball: file:projects/analyzer.tgz}
     id: file:projects/analyzer.tgz
     name: '@rush-temp/analyzer'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@types/node': 14.18.33
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
@@ -19182,12 +19177,12 @@ packages:
     dev: false
 
   file:projects/ecommerce-checkout.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-6Ga+StTTZfbkyePNN52HJ+6R6qqaxIkA5qJXAyYXeVXtDeveqxACvTEe3j+3iju3NKU0ESscEQOL+RWby10cBA==, tarball: file:projects/ecommerce-checkout.tgz}
+    resolution: {integrity: sha512-7UMduLgXQDtAqueOiMaVAoXb+CTnQkPiqvKhYfvRluKE5fqYOSj5+SKdtiW6Wf/l73uki+I3mkFtddxx2TaqgA==, tarball: file:projects/ecommerce-checkout.tgz}
     id: file:projects/ecommerce-checkout.tgz
     name: '@rush-temp/ecommerce-checkout'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19197,34 +19192,48 @@ packages:
       '@types/react-dom': 18.0.9
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       source-map-explorer: 2.5.3
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
+      - '@swc/core'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
+      - debug
+      - esbuild
       - fibers
+      - node-notifier
       - node-sass
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - ts-node
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: false
 
   file:projects/fashion-ecommerce.tgz:
-    resolution: {integrity: sha512-0nP5nKypwTanhbqMCod6t89eQC/M6VXjQKhrVvXhXHMbAGik+BSRA86dBSHmSYsM0ZB7Vc/WqTZzHaLa2ytsnw==, tarball: file:projects/fashion-ecommerce.tgz}
+    resolution: {integrity: sha512-8L9HTRlv8DiO5rzm5ltA9QuIabzeOrHoadakEuiwDPmrlJeDC52r1dwRYjWhmWRA8CYt3ImD5xxOdnFO1eRcOA==, tarball: file:projects/fashion-ecommerce.tgz}
     name: '@rush-temp/fashion-ecommerce'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19242,47 +19251,60 @@ packages:
       react: 18.2.0
       react-device-detect: 1.17.0_react-dom@18.2.0+react@18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       react-spring: 9.5.5_react-dom@18.2.0+react@18.2.0
       styled-components: 5.3.6_react-dom@18.2.0+react@18.2.0
       ts-node: 10.9.1_8a69e7e02b4164030d9066f1fe6648f4
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
       - '@react-three/fiber'
       - '@swc/core'
       - '@swc/wasm'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
+      - debug
       - encoding
+      - esbuild
       - fibers
       - konva
+      - node-notifier
       - node-sass
       - react-is
       - react-konva
       - react-native
       - react-zdog
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - three
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
       - zdog
     dev: false
 
   file:projects/flight-booking.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-hMAP8wZi95STqScd6yuJoazH5EUiUz0w2tkM9wFWNW2hlAozbpjg8cFVg+Fdj6f+VGsUfX7zhDWE7m/ozRldXA==, tarball: file:projects/flight-booking.tgz}
+    resolution: {integrity: sha512-wFsm4kgA7g09h9eTZVVi4bUvY3b/qAlFKezWak0xTQZAyS/iiS7bME/o2mxO+hkP0aulcX10trHQCRcMfHPvpw==, tarball: file:projects/flight-booking.tgz}
     id: file:projects/flight-booking.tgz
     name: '@rush-temp/flight-booking'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19292,24 +19314,38 @@ packages:
       '@types/react-dom': 18.0.9
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       source-map-explorer: 2.5.3
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
+      - '@swc/core'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
+      - debug
+      - esbuild
       - fibers
+      - node-notifier
       - node-sass
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - ts-node
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: false
@@ -19328,12 +19364,12 @@ packages:
     dev: false
 
   file:projects/moderation.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-aNmLfx29Pd14BnL60RECQTZEzfw5DuKiICanF9lSgAP1+gQbwWRhGmOIEFOizWWYYXiFJSLWGzl1Y5u6bFCdkA==, tarball: file:projects/moderation.tgz}
+    resolution: {integrity: sha512-/tRTjLlxpM4dVIEnoYkqI2jo+HZGL/rdLlLCq3UDsPi0aMuaNEGm0gaISWGvc+6vJtdtjaxrhyUcpj2hckmrkA==, tarball: file:projects/moderation.tgz}
     id: file:projects/moderation.tgz
     name: '@rush-temp/moderation'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19346,24 +19382,38 @@ packages:
       plyr-react: 4.0.0-alpha.1_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       sentence-case: 3.0.4
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
+      - '@swc/core'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
+      - debug
+      - esbuild
       - fibers
+      - node-notifier
       - node-sass
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - ts-node
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: false
@@ -19565,12 +19615,12 @@ packages:
     dev: false
 
   file:projects/smart-home.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-4fsiA10qJdcH/4BPaCAqJjH7HM9I1MsTI4gqovBD2Nu5DodFleG3IcsX3/2GCWgTr3wMPuWhMTv5vnG5HAE9kg==, tarball: file:projects/smart-home.tgz}
+    resolution: {integrity: sha512-fc1hvfZzgE9j/cKjZuTRmK+YCeveOwevY+HZDESCsS884Yaxbeo16aVhrQQRktiKllSq1oDaIXTbgQmiZu7GLQ==, tarball: file:projects/smart-home.tgz}
     id: file:projects/smart-home.tgz
     name: '@rush-temp/smart-home'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19588,44 +19638,58 @@ packages:
       react-image-webp: 0.7.0
       react-map-interaction: 2.1.0_prop-types@15.8.1+react@18.2.0
       react-refresh: 0.9.0
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       react-spring: 9.5.5_react-dom@18.2.0+react@18.2.0
       styled-components: 5.3.6_react-dom@18.2.0+react@18.2.0
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
       - '@react-three/fiber'
+      - '@swc/core'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
+      - debug
+      - esbuild
       - fibers
       - konva
+      - node-notifier
       - node-sass
       - react-is
       - react-konva
       - react-native
       - react-zdog
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - three
       - ts-node
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
       - zdog
     dev: false
 
   file:projects/speech-to-text.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-G4f0EmCa1p4oCwftS27r2rHDyANKgF3RIxYSzKWBm/dwB5POAeAgTCSTISESdpdTccI1d6lG7rwheKo1wHGgmg==, tarball: file:projects/speech-to-text.tgz}
+    resolution: {integrity: sha512-7+kPEvvZLOKV1iXtdvGtxadIxZtzW7aCCfX2rVhLtYcMkeHtQfqahJ08CIA1dAlaAXF86Bq32TKHYGXaFhk0Ug==, tarball: file:projects/speech-to-text.tgz}
     id: file:projects/speech-to-text.tgz
     name: '@rush-temp/speech-to-text'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19637,35 +19701,48 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-openai-api: 1.0.2_9600c6325dd30b1815a1414ccdd088fe
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
+      - '@swc/core'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
       - debug
+      - esbuild
       - fibers
+      - node-notifier
       - node-sass
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - ts-node
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: false
 
   file:projects/voice-search.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-TH64EuDqXBMdg4V9xqaAAK7r1ZbPxHIP0gSRy+xyK4sFW350Kl/Za3Jlqz6JcPz5QDve5JNEcDJHoPE3cpDiZA==, tarball: file:projects/voice-search.tgz}
+    resolution: {integrity: sha512-g31jyroJkeN/YE5b1D8/PYZuZBRFqvwXNMhd7XOo0sYzx+IC/HJ/Mf0b/Sl0HB4mwSXU5XiScPjtubdrIouhzg==, tarball: file:projects/voice-search.tgz}
     id: file:projects/voice-search.tgz
     name: '@rush-temp/voice-search'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.37_react-dom@18.2.0+react@18.2.0
+      '@speechly/demo-navigation': 0.1.38
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19676,23 +19753,37 @@ packages:
       modern-normalize: 1.1.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 4.0.3_bb15ce2993c548faf38f556d6c0a445d
+      react-scripts: 5.0.1_bb15ce2993c548faf38f556d6c0a445d
       typescript: 4.9.4
     transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - '@parcel/css'
+      - '@swc/core'
       - '@testing-library/dom'
+      - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
       - canvas
+      - clean-css
+      - csso
+      - debug
+      - esbuild
       - fibers
+      - node-notifier
       - node-sass
+      - rework
+      - rework-visit
       - sass
+      - sass-embedded
       - sockjs-client
       - supports-color
       - ts-node
       - type-fest
+      - uglify-js
       - utf-8-validate
+      - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: false

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,10 +24,7 @@ specifiers:
   '@rush-temp/smart-home': file:./projects/smart-home.tgz
   '@rush-temp/speech-to-text': file:./projects/speech-to-text.tgz
   '@rush-temp/voice-search': file:./projects/voice-search.tgz
-  '@speechly/demo-navigation': ^0.1.38
-  '@testing-library/jest-dom': ^4.2.4
-  '@testing-library/react': ^9.3.2
-  '@testing-library/user-event': ^7.1.2
+  '@speechly/demo-navigation': ^0.1.39
   '@tsconfig/svelte': ^1.0.0
   '@types/base-64': ^0.1.3
   '@types/jest': ^25
@@ -123,10 +120,7 @@ dependencies:
   '@rush-temp/smart-home': file:projects/smart-home.tgz_ts-node@10.9.1
   '@rush-temp/speech-to-text': file:projects/speech-to-text.tgz_ts-node@10.9.1
   '@rush-temp/voice-search': file:projects/voice-search.tgz_ts-node@10.9.1
-  '@speechly/demo-navigation': 0.1.38
-  '@testing-library/jest-dom': 4.2.4
-  '@testing-library/react': 9.5.0
-  '@testing-library/user-event': 7.2.1
+  '@speechly/demo-navigation': 0.1.39
   '@tsconfig/svelte': 1.0.13
   '@types/base-64': 0.1.3
   '@types/jest': 25.2.3
@@ -3248,8 +3242,8 @@ packages:
       '@sinonjs/commons': 1.8.5
     dev: false
 
-  /@speechly/demo-navigation/0.1.38:
-    resolution: {integrity: sha512-k6/8QbOQ6U1qY6G93UUy3ii5kiUvEttl10kRK0MK0NSMu8r+RsSy6J2shUlLG9N8xl3w7+My8/pVXH/dMLNWHA==}
+  /@speechly/demo-navigation/0.1.39:
+    resolution: {integrity: sha512-UFt6fla0IHXpNm3nQIRGw6R29i7NuAyjb9xbHJTtTXKQdJc876jzIQPMgqVed0trGcosE7HOliJz2C7jjODAKg==}
     dev: false
 
   /@surma/rollup-plugin-off-main-thread/1.4.2:
@@ -3417,18 +3411,6 @@ packages:
       lodash: 4.17.21
       pretty-format: 24.9.0
       redent: 3.0.0
-    dev: false
-
-  /@testing-library/react/9.5.0:
-    resolution: {integrity: sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==}
-    engines: {node: '>=8'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      '@babel/runtime': 7.20.1
-      '@testing-library/dom': 6.16.0
-      '@types/testing-library__react': 9.1.3
     dev: false
 
   /@testing-library/react/9.5.0_react-dom@18.2.0+react@18.2.0:
@@ -19011,12 +18993,12 @@ packages:
     dev: false
 
   file:projects/analyzer.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-9mv/f0h6pP6vpvwdyHfCk1uN6iQPW6CyFWcClnb8lJlOVA2HUA6dd05SZB36QfKbxVy7BUzDwaJ/CpmMfZMEAg==, tarball: file:projects/analyzer.tgz}
+    resolution: {integrity: sha512-9cM4Vq9TQ4mo3UH2KaEH7cj3iTmcbkrWE+fX9OS4R/Z0iRzdFACyaCafD2shPFp9ydJL8wNX51kFwLbhkSr3Zw==, tarball: file:projects/analyzer.tgz}
     id: file:projects/analyzer.tgz
     name: '@rush-temp/analyzer'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@types/node': 14.18.33
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
@@ -19177,12 +19159,12 @@ packages:
     dev: false
 
   file:projects/ecommerce-checkout.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-7UMduLgXQDtAqueOiMaVAoXb+CTnQkPiqvKhYfvRluKE5fqYOSj5+SKdtiW6Wf/l73uki+I3mkFtddxx2TaqgA==, tarball: file:projects/ecommerce-checkout.tgz}
+    resolution: {integrity: sha512-Z7NNEZPQNQqEjf+aoY7Ka+pdl9U5trlKXRMossoJRa9Snh0b5LpWfc4JXZkuMqHK4IizilH5fABrSXR5WPWSnQ==, tarball: file:projects/ecommerce-checkout.tgz}
     id: file:projects/ecommerce-checkout.tgz
     name: '@rush-temp/ecommerce-checkout'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19200,7 +19182,6 @@ packages:
       - '@babel/plugin-transform-react-jsx'
       - '@parcel/css'
       - '@swc/core'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
@@ -19229,11 +19210,11 @@ packages:
     dev: false
 
   file:projects/fashion-ecommerce.tgz:
-    resolution: {integrity: sha512-8L9HTRlv8DiO5rzm5ltA9QuIabzeOrHoadakEuiwDPmrlJeDC52r1dwRYjWhmWRA8CYt3ImD5xxOdnFO1eRcOA==, tarball: file:projects/fashion-ecommerce.tgz}
+    resolution: {integrity: sha512-DgFIzhNXIEndQf3x6Pfw1WGQoQy7zY5GsxoMFU2243j60AymbhNwYMgeVeLhmVdK7dxmVzj/oriejXtcqZ0nMQ==, tarball: file:projects/fashion-ecommerce.tgz}
     name: '@rush-temp/fashion-ecommerce'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19263,7 +19244,6 @@ packages:
       - '@react-three/fiber'
       - '@swc/core'
       - '@swc/wasm'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
@@ -19299,12 +19279,12 @@ packages:
     dev: false
 
   file:projects/flight-booking.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-wFsm4kgA7g09h9eTZVVi4bUvY3b/qAlFKezWak0xTQZAyS/iiS7bME/o2mxO+hkP0aulcX10trHQCRcMfHPvpw==, tarball: file:projects/flight-booking.tgz}
+    resolution: {integrity: sha512-cpz/a2yEtbzgiBJ/RhIa/EQFpKn8qLB5U20Y7tbt2hLbytFafkOHN4n1hGqRzQbvJedWlJ3bnIhaojIwWw4Diw==, tarball: file:projects/flight-booking.tgz}
     id: file:projects/flight-booking.tgz
     name: '@rush-temp/flight-booking'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19322,7 +19302,6 @@ packages:
       - '@babel/plugin-transform-react-jsx'
       - '@parcel/css'
       - '@swc/core'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
@@ -19364,12 +19343,12 @@ packages:
     dev: false
 
   file:projects/moderation.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-/tRTjLlxpM4dVIEnoYkqI2jo+HZGL/rdLlLCq3UDsPi0aMuaNEGm0gaISWGvc+6vJtdtjaxrhyUcpj2hckmrkA==, tarball: file:projects/moderation.tgz}
+    resolution: {integrity: sha512-9GkIYJqwBZQwBsrNkNp1zLnShPaRCp0dtkY0DkrKu/inXhgSgEdyRxmDVbKjo7xa6Lwl94QdV6K3aiT4XuE/Hw==, tarball: file:projects/moderation.tgz}
     id: file:projects/moderation.tgz
     name: '@rush-temp/moderation'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19390,7 +19369,6 @@ packages:
       - '@babel/plugin-transform-react-jsx'
       - '@parcel/css'
       - '@swc/core'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
@@ -19615,12 +19593,12 @@ packages:
     dev: false
 
   file:projects/smart-home.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-fc1hvfZzgE9j/cKjZuTRmK+YCeveOwevY+HZDESCsS884Yaxbeo16aVhrQQRktiKllSq1oDaIXTbgQmiZu7GLQ==, tarball: file:projects/smart-home.tgz}
+    resolution: {integrity: sha512-3nGvrbsFKT3RaANR9aoNiBiTcsu2lZ3r2oy9IvPOBTmmekEOfb1n7oT4j4omhwn2PIxrLE51hbYLdBjX2AlSqg==, tarball: file:projects/smart-home.tgz}
     id: file:projects/smart-home.tgz
     name: '@rush-temp/smart-home'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19648,7 +19626,6 @@ packages:
       - '@parcel/css'
       - '@react-three/fiber'
       - '@swc/core'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
@@ -19684,12 +19661,12 @@ packages:
     dev: false
 
   file:projects/speech-to-text.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-7+kPEvvZLOKV1iXtdvGtxadIxZtzW7aCCfX2rVhLtYcMkeHtQfqahJ08CIA1dAlaAXF86Bq32TKHYGXaFhk0Ug==, tarball: file:projects/speech-to-text.tgz}
+    resolution: {integrity: sha512-9oy0uH2/0YPGOyWhNtpLZGBnPwYzxoDj3EUACpWQesm/aUBLbkHXwbMQDd9P4BRLh4bXi8KxApg0uNZfKaS1hg==, tarball: file:projects/speech-to-text.tgz}
     id: file:projects/speech-to-text.tgz
     name: '@rush-temp/speech-to-text'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19708,7 +19685,6 @@ packages:
       - '@babel/plugin-transform-react-jsx'
       - '@parcel/css'
       - '@swc/core'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil
@@ -19737,12 +19713,12 @@ packages:
     dev: false
 
   file:projects/voice-search.tgz_ts-node@10.9.1:
-    resolution: {integrity: sha512-g31jyroJkeN/YE5b1D8/PYZuZBRFqvwXNMhd7XOo0sYzx+IC/HJ/Mf0b/Sl0HB4mwSXU5XiScPjtubdrIouhzg==, tarball: file:projects/voice-search.tgz}
+    resolution: {integrity: sha512-VczozYIndc0kDYu5VmytTFjTAePgmmUpA6SXBPp8Giv4RoXx+yRxRW2wEJRcltPqvKYjcX810pB2u6RwUNjLYg==, tarball: file:projects/voice-search.tgz}
     id: file:projects/voice-search.tgz
     name: '@rush-temp/voice-search'
     version: 0.0.0
     dependencies:
-      '@speechly/demo-navigation': 0.1.38
+      '@speechly/demo-navigation': 0.1.39
       '@testing-library/jest-dom': 4.2.4
       '@testing-library/react': 9.5.0_react-dom@18.2.0+react@18.2.0
       '@testing-library/user-event': 7.2.1
@@ -19760,7 +19736,6 @@ packages:
       - '@babel/plugin-transform-react-jsx'
       - '@parcel/css'
       - '@swc/core'
-      - '@testing-library/dom'
       - '@types/babel__core'
       - '@types/webpack'
       - bufferutil

--- a/demos/analyzer/package.json
+++ b/demos/analyzer/package.json
@@ -5,7 +5,7 @@
   "homepage": "/analyzer/",
   "dependencies": {
     "@speechly/browser-client": "^2.6.2",
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/logkit": ">=1.0.0",
     "clsx": "^1.2.1",

--- a/demos/analyzer/package.json
+++ b/demos/analyzer/package.json
@@ -5,7 +5,7 @@
   "homepage": "/analyzer/",
   "dependencies": {
     "@speechly/browser-client": "^2.6.2",
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/logkit": ">=1.0.0",
     "clsx": "^1.2.1",

--- a/demos/ecommerce-checkout/package.json
+++ b/demos/ecommerce-checkout/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/checkout/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/logkit": ">=1.0.0",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
@@ -13,14 +13,10 @@
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "react-scripts": "^4.0.3",
+    "react-scripts": "^5.0.1",
     "source-map-explorer": "^2.5.2",
     "typescript": "^4.6.4"
   },
@@ -28,7 +24,6 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/ecommerce-checkout/package.json
+++ b/demos/ecommerce-checkout/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/checkout/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/logkit": ">=1.0.0",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",

--- a/demos/ecommerce-checkout/src/setupTests.ts
+++ b/demos/ecommerce-checkout/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/demos/fashion-ecommerce/package.json
+++ b/demos/fashion-ecommerce/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/fashion/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",

--- a/demos/fashion-ecommerce/package.json
+++ b/demos/fashion-ecommerce/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/fashion/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",
@@ -17,10 +17,6 @@
     "classnames": "~2.3.1"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/node-fetch": "^2.5.7",
     "@types/react": "^18",
@@ -29,7 +25,7 @@
     "@types/pubsub-js": "^1.8.1",
     "csvtojson": "^2.0.10",
     "node-fetch": "^2.6.1",
-    "react-scripts": "^4.0.3",
+    "react-scripts": "^5.0.1",
     "ts-node": ">=9.0.0",
     "typescript": "^4.6.4"
   },
@@ -41,7 +37,6 @@
     "build": "react-scripts build",
     "release": "pnpm build && set -o allexport;. ./.env;set +o allexport && gsutil -m cp -r build/* $REACT_APP__DEPLOY_PROD_URI",
     "staging": "pnpm build && set -o allexport;. ./.env;set +o allexport && rsync -avz --delete build/ $REACT_APP__DEPLOY_STAGING_URI",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/fashion-ecommerce/src/App.test.tsx
+++ b/demos/fashion-ecommerce/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/demos/fashion-ecommerce/src/setupTests.ts
+++ b/demos/fashion-ecommerce/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/demos/flight-booking/package.json
+++ b/demos/flight-booking/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "booking",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/react-voice-forms": "1.3.5",
@@ -13,14 +13,10 @@
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "react-scripts": "^4.0.3",
+    "react-scripts": "^5.0.1",
     "source-map-explorer": "^2.5.2",
     "typescript": "^4.6.4"
   },
@@ -28,7 +24,6 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/flight-booking/package.json
+++ b/demos/flight-booking/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "booking",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/react-voice-forms": "1.3.5",

--- a/demos/flight-booking/src/setupTests.ts
+++ b/demos/flight-booking/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/demos/moderation/package.json
+++ b/demos/moderation/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/moderation/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/logkit": ">=1.0.0",
     "react": "^18",
@@ -16,19 +16,14 @@
     "plyr-react": "4.0.0-alpha.1"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/moderation/package.json
+++ b/demos/moderation/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/moderation/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/logkit": ">=1.0.0",
     "react": "^18",

--- a/demos/moderation/src/App.css
+++ b/demos/moderation/src/App.css
@@ -1,11 +1,11 @@
 .App {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - 48px);
+  min-height: calc(100vh - 64px);
 }
 
 .Header {
-  background-color: #00050A;
+  background-color: var(--header);
 }
 
 .Header__inner {
@@ -37,7 +37,7 @@
   --plyr-font-family: 'Inter', sans-serif;
   --plyr-font-size-small: 14px;
 
-  background-color: #00050A;
+  background-color: var(--header);
   position: sticky;
   top: 0;
   z-index: 10;

--- a/demos/moderation/src/App.tsx
+++ b/demos/moderation/src/App.tsx
@@ -11,6 +11,7 @@ import "./plyr.css";
 
 const playerOptions: Plyr.Options = {
   controls: ["play", "progress", "current-time", "mute", "volume"],
+  volume: 0.5,
   invertTime: false,
   keyboard: { focused: false, global: false }
 };

--- a/demos/moderation/src/index.css
+++ b/demos/moderation/src/index.css
@@ -2,6 +2,7 @@
 
 :root {
   --bg: #fff;
+  --header: #0F1923;
   --segment: #F3F4F6;
   --segment-active: #E5E9EC;
   --text-primary: #00050A;

--- a/demos/moderation/src/setupTests.ts
+++ b/demos/moderation/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/demos/smart-home/package.json
+++ b/demos/smart-home/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "smart-home",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",
@@ -16,16 +16,12 @@
     "react-image-webp": "^0.7.0",
     "react-map-interaction": "^2.0.0",
     "react-refresh": "^0.9.0",
-    "react-scripts": "^4.0.3",
+    "react-scripts": "^5.0.1",
     "react-spring": "^9.4.4",
     "styled-components": ">=5.3.3",
     "typescript": "^4.6.4"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/pubsub-js": "^1.8.1",
     "@types/react": "^18",
@@ -35,7 +31,6 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/smart-home/package.json
+++ b/demos/smart-home/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "smart-home",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",

--- a/demos/smart-home/src/App.test.tsx
+++ b/demos/smart-home/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/demos/smart-home/src/setupTests.ts
+++ b/demos/smart-home/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';

--- a/demos/speech-to-text/package.json
+++ b/demos/speech-to-text/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/speech-to-text/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",

--- a/demos/speech-to-text/package.json
+++ b/demos/speech-to-text/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/speech-to-text/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",
@@ -14,19 +14,14 @@
     "react-openai-api": "^1.0.2"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/speech-to-text/src/setupTests.ts
+++ b/demos/speech-to-text/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';

--- a/demos/voice-search/package.json
+++ b/demos/voice-search/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/voice-search/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.37",
+    "@speechly/demo-navigation": "^0.1.38",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",
@@ -14,19 +14,14 @@
     "modern-normalize": "~1.1.0"
   },
   "devDependencies": {
-    "react-scripts": "^4.0.3",
-    "@types/jest": "^25",
     "@types/node": "^14",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/demos/voice-search/package.json
+++ b/demos/voice-search/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/voice-search/",
   "dependencies": {
-    "@speechly/demo-navigation": "^0.1.38",
+    "@speechly/demo-navigation": "^0.1.39",
     "@speechly/react-client": "^2.2.1",
     "@speechly/react-ui": "^2.7.3",
     "@speechly/logkit": ">=1.0.0",

--- a/demos/voice-search/src/SearchView.css
+++ b/demos/voice-search/src/SearchView.css
@@ -10,7 +10,7 @@
 
 .SearchView {
   position: absolute;
-  top: 48px;
+  top: 64px;
   right: 0;
   bottom: 0;
   left: 0;

--- a/demos/voice-search/src/setupTests.ts
+++ b/demos/voice-search/src/setupTests.ts
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
### What

Take version 0.1.39 of `demo-navigation` into use. Some demos required layout changes, since the new navigation is bigger. Also, some maintenance was also required:

- Removed tests and test dependencies from all demos since they were unused and caused `rush build` to fail.
- Update all demos to use `react-scripts` version 5.0.1

### Why

Marketing dept wanted this
