### PR TITLE
Fix example links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ yarn run precommit
 
 ## Test setup
 
-You can use the [browser-client-example](https://github.com/speechly/browser-client-example) as your test setup. You will need a Speechly app ID to go with it.
+You can use the [Speechly Browser Client Example](https://github.com/speechly/speechly/tree/main/examples/browser-client-example) as your test setup. You will need a Speechly App ID to go with it.
 
 You can set it up by using `yarn link`:
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,6 @@ rush change -b origin/main
 
 ## Related repositories
 
-- [Android Client Library](https://github.com/speechly/android-client)
-- [iOS Client Library](https://github.com/speechly/ios-client)
+- [Speechly Android Client](https://github.com/speechly/android-client)
+- [Speechly iOS Client](https://github.com/speechly/ios-client)
 - [Speechly API gRPC protos and pre-compiled stubs](https://github.com/speechly/api)

--- a/common/changes/@speechly/browser-client/fix-example-links_2023-01-30-17-23.json
+++ b/common/changes/@speechly/browser-client/fix-example-links_2023-01-30-17-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/browser-client",
+      "comment": "Update documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/browser-client"
+}

--- a/common/changes/@speechly/react-client/fix-example-links_2023-01-30-17-23.json
+++ b/common/changes/@speechly/react-client/fix-example-links_2023-01-30-17-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@speechly/react-client",
+      "comment": "Update documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@speechly/react-client"
+}

--- a/examples/browser-client-example/README.md
+++ b/examples/browser-client-example/README.md
@@ -4,9 +4,9 @@ This is a simple demo showcasing usage of [Speechly API](https://www.speechly.co
 
 Built with:
 
-- [speechly-browser-client](https://github.com/speechly/browser-client)
+- [Speechly Browser Client](https://github.com/speechly/speechly/tree/main/libraries/browser-client)
 - [TypeScript](https://www.typescriptlang.org)
-- [create-react-app](https://github.com/facebook/create-react-app).
+- [Create React App](https://github.com/facebook/create-react-app).
 
 A working demo of this example can be found here: https://speechly.github.io/browser-client-example/ 
 

--- a/examples/browser-client-example/README.md
+++ b/examples/browser-client-example/README.md
@@ -1,6 +1,6 @@
-# browser-client-example
+# Speechly Browser Client Example
 
-This is a simple demo showcasing usage of [Speechly API](https://www.speechly.com/?utm_source=github&utm_medium=browser-client-example&utm_campaign=header). Speechly configuration for the app can be found in [speechly_config.sal](speechly_config.sal).
+This is a simple demo showcasing usage of [Speechly Browser Client](https://github.com/speechly/speechly/tree/main/libraries/browser-client).
 
 Built with:
 
@@ -8,7 +8,20 @@ Built with:
 - [TypeScript](https://www.typescriptlang.org)
 - [Create React App](https://github.com/facebook/create-react-app).
 
-A working demo of this example can be found here: https://speechly.github.io/browser-client-example/ 
+A working demo of this example can be found at https://speechly.github.io/browser-client-example/ 
+
+## Before you start
+
+Create and deploy your own Speechly application, following [our quick start tutorial](https://docs.speechly.com/quick-start/).
+
+Use the configuration from [speechly_config.sal](speechly_config.sal), remember to declare the entities and intents.
+
+Copy the example app using [degit](https://github.com/Rich-Harris/degit):
+
+```bash
+npx degit speechly/speechly/examples/browser-client-example my-app
+cd my-app
+```
 
 ## Run it locally
 
@@ -26,7 +39,7 @@ npm start
 
 You can check out the code in [index.ts](src/index.ts) and the layout in [index.html](public/index.html).
 
-To use your own appId with this example, run the following prior to `npm start`:
+To use your own **App ID** with this example, run the following prior to `npm start`:
 
 ```shell
 # Configure your Speechly app ID
@@ -39,6 +52,6 @@ export REACT_APP_LANGUAGE="your-app-language"
 export REACT_APP_TIMEZONE="your-app-timezone"
 ```
 
-For instructions on how to get started on the Speechly free tier and obtain your appId, please see the [Quick Start Guide](https://docs.speechly.com/quick-start).
+## Contributing
 
-Note that this example is part of a monorepository that uses [rush](https://rush.js) and [pnpm](https://pnpm.io) as build tools. If you are interested in contributing, please check the instructions in the [root level README](../../README.md#how-to-use-this-repository).
+Note that this example is part of a monorepository that uses [rush](https://rush.js) and [pnpm](https://pnpm.io) as build tools. If you are interested in contributing, please check the instructions in the [root level README](../../README.md#how-to-use-this-rush-monorepository).

--- a/examples/react-client-example/README.md
+++ b/examples/react-client-example/README.md
@@ -1,13 +1,26 @@
-# react-client-example
+# Speechly React Client Example
 
-This is a simple demo showcasing usage of [Speechly API](https://www.speechly.com/?utm_source=github&utm_medium=browser-client-example&utm_campaign=header). Speechly configuration for the app can be found in [speechly_config.sal](speechly_config.sal).
+This is a simple demo showcasing usage of [Speechly React Client](https://github.com/speechly/speechly/tree/main/libraries/react-client).
 
 Built with:
 
 - [Speechly React Client](https://github.com/speechly/speechly/tree/main/libraries/react-client)
 - [Create React App](https://github.com/facebook/create-react-app).
 
-Check it out at https://speechly.github.io/react-example-repo-filtering/.
+A working demo of this example can be found at https://speechly.github.io/react-example-repo-filtering/.
+
+## Before you start
+
+Create and deploy your own Speechly application, following [our quick start tutorial](https://docs.speechly.com/quick-start/).
+
+Use the configuration from [speechly_config.sal](speechly_config.sal), remember to declare the entities and intents.
+
+Copy the example app using [degit](https://github.com/Rich-Harris/degit):
+
+```bash
+npx degit speechly/speechly/examples/react-client-example my-app
+cd my-app
+```
 
 ## Run it locally
 
@@ -25,7 +38,7 @@ npm start
 
 You can check out the code in [App.js](src/App.js).
 
-To use your own appId with this example, run the following prior to `npm start`:
+To use your own **App ID** with this example, run the following prior to `npm start`:
 
 ```shell
 # Configure your Speechly app ID
@@ -35,6 +48,4 @@ export REACT_APP_APP_ID="your-app-id"
 export REACT_APP_LANGUAGE="your-app-language"
 ```
 
-For instructions on how to get started on the Speechly free tier and obtain your appId, please see the [Quick Start Guide](https://docs.speechly.com/quick-start).
-
-Note that this example is part of a monorepository that uses [rush](https://rush.js) and [pnpm](https://pnpm.io) as build tools. If you are interested in contributing, please check the instructions in the [root level README](../../README.md#how-to-use-this-repository).
+Note that this example is part of a monorepository that uses [rush](https://rush.js) and [pnpm](https://pnpm.io) as build tools. If you are interested in contributing, please check the instructions in the [root level README](../../README.md#how-to-use-this-rush-monorepository).

--- a/examples/react-client-example/README.md
+++ b/examples/react-client-example/README.md
@@ -4,8 +4,8 @@ This is a simple demo showcasing usage of [Speechly API](https://www.speechly.co
 
 Built with:
 
-- [speechly-react-client](https://github.com/speechly/react-client)
-- [create-react-app](https://github.com/facebook/create-react-app).
+- [Speechly React Client](https://github.com/speechly/speechly/tree/main/libraries/react-client)
+- [Create React App](https://github.com/facebook/create-react-app).
 
 Check it out at https://speechly.github.io/react-example-repo-filtering/.
 

--- a/libraries/browser-client/README.md
+++ b/libraries/browser-client/README.md
@@ -22,17 +22,13 @@
 [![npm](https://img.shields.io/npm/v/@speechly/browser-client?color=cb3837&logo=npm)](https://www.npmjs.com/package/@speechly/browser-client)
 [![license](http://img.shields.io/:license-mit-blue.svg)](/LICENSE)
 
-With the Speechly browser client you can add voice features to any website. It handles authentication, audio capture, network streaming and connection management with the Speechly Voice API.
+With the Speechly browser client you can add voice features to any website. It handles authentication, audio capture, network streaming and connection management with the Speechly Streaming API.
 
-Check out the [browser-client-example](https://github.com/speechly/speechly/tree/main/examples/browser-client-example) repository for a demo app built using this client.
+If you are using React, you can use the [Speechly React Client](https://github.com/speechly/speechly/tree/main/libraries/react-client) instead. It provides the same functionalities, but provides a programming model that is idiomatic to React.
+
+Check out the [browser client example](https://github.com/speechly/speechly/tree/main/examples/browser-client-example) for an example app built using this client.
 
 🚧 Browser client `v2.0` is a breaking change. Read more about the major changes and how to upgrade from [our blog post](https://speechly.com/blog/speechly-browser-client-v2-released).
-
-⚡️ If you are using React, you can use our [React client](https://github.com/speechly/speechly/tree/main/libraries/react-client) instead. It provides the same functionalities, but provides a programming model that is idiomatic to React.
-
-## API Documentation
-
-- [API documentation (TypeDoc generated)](https://github.com/speechly/speechly/blob/main/libraries/browser-client/docs/classes/client.BrowserClient.md)
 
 ## Using in web sites built with eg. rollup
 
@@ -153,8 +149,9 @@ Please use a HTML server to view the example. Running it as a file will not work
 
 ## Documentation
 
-- [API documentation](https://github.com/speechly/speechly/blob/main/libraries/browser-client/docs/classes/client.BrowserClient.md) in GitHub
-- [Basic usage in docs.speechly.com](https://docs.speechly.com/?utm_source=github&utm_medium=browser-client&utm_campaign=text) for more information.
+- [API reference](https://github.com/speechly/speechly/blob/main/libraries/browser-client/docs/classes/client.BrowserClient.md) (GitHub)
+- [Basic usage](https://dreamy-cori-a02de1.netlify.app/client-libraries/usage/) (Docs)
+- [Example application](https://github.com/speechly/speechly/tree/main/examples/browser-client-example)
 
 ## Contributing
 

--- a/libraries/browser-client/package.json
+++ b/libraries/browser-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@speechly/browser-client",
   "version": "2.6.2",
-  "description": "Browser client for Speechly API",
+  "description": "Browser client for Speechly Streaming API",
   "keywords": [
     "client",
     "voice",

--- a/libraries/react-client/README.md
+++ b/libraries/react-client/README.md
@@ -22,9 +22,9 @@
 [![npm](https://img.shields.io/npm/v/@speechly/react-client?color=cb3837&logo=npm)](https://www.npmjs.com/package/@speechly/react-client)
 [![license](http://img.shields.io/:license-mit-blue.svg)](/LICENSE)
 
-This repository contains source code for the React client for [Speechly](https://www.speechly.com/?utm_source=github&utm_medium=react-client&utm_campaign=text) SLU API. Speechly allows you to easily build applications with voice-enabled UIs.
+With the Speechly React client you can add voice features to any React project. It handles authentication, audio capture, network streaming and connection management with the Speechly Streaming API.
 
-Check out [Speechly documentation](https://docs.speechly.com//client-libraries/react-client/?utm_source=github&utm_medium=react-client&utm_campaign=text) for a tutorial on how to build a voice filtering app using this client.
+Check out the [react client example](https://github.com/speechly/speechly/tree/main/examples/react-client-example) for an example app built using this client.
 
 ## Before you start
 
@@ -95,9 +95,9 @@ Navigate to http://localhost:3000 to see your app running!
 ## Documentation
 
 - [API reference](https://github.com/speechly/speechly/blob/main/libraries/react-client/docs/classes/context.SpeechProvider.md) (GitHub)
-- [Basic usage](https://docs.speechly.com/client-libraries/usage/?platform=React) (Docs)
-- [Advanced usage](https://docs.speechly.com/client-libraries/using-react-client/) (Docs)
-- Check out the [react-example-repo-filtering](https://github.com/speechly/react-example-repo-filtering) repository for a example app built using this client.
+- [Basic usage](https://dreamy-cori-a02de1.netlify.app/client-libraries/usage/?platform=React) (Docs)
+- [Advanced usage](https://dreamy-cori-a02de1.netlify.app/client-libraries/using-react-client/) (Docs)
+- [Example application](https://github.com/speechly/speechly/tree/main/examples/react-client-example)
 
 ## Contributing
 

--- a/libraries/react-client/package.json
+++ b/libraries/react-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@speechly/react-client",
   "version": "2.2.1",
-  "description": "React client for Speechly SLU API",
+  "description": "React client for Speechly Streaming API",
   "keywords": [
     "react",
     "reactjs",
@@ -42,7 +42,7 @@
     "directory": "libraries/react-client"
   },
   "bugs": {
-    "url": "https://github.com/speechly/react-client/issues"
+    "url": "https://github.com/speechly/speechly/issues"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
### What

- Fix old/broken links in browser/react client readmes
- Improve react/browser client examples readmes
- Unify taxonomy, stylize text and improve examples getting started

### Why

We were linking to old repos or obsolete urls. Also the examples instructions needed some improvement.

