### PR TITLE
Fix/improve audio events

### DIFF
--- a/demos/analyzer/src/App.css
+++ b/demos/analyzer/src/App.css
@@ -21,10 +21,7 @@ body {
 /* Sidebar */
 
 .Sidebar {
-  display: flex;
-  flex-direction: column;
   flex-shrink: 0;
-  padding: 24px;
   height: 100%;
   border-right: 1px solid var(--border);
   overflow-y: auto;
@@ -38,23 +35,21 @@ body {
 }
 
 .Sidebar__section {
-  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--border);
+}
+
+.Sidebar__section:first-of-type {
+  border-top: none;
 }
 
 .Sidebar__title {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: 16px;
-  margin-top: 16px;
-  margin-bottom: 8px;
-  border-top: 1px solid var(--border);
-}
-
-.Sidebar__title:first-of-type {
-  padding-top: 0;
-  margin-top: 0;
-  border-top: none;
 }
 
 .Sidebar__title h4 {
@@ -76,13 +71,8 @@ body {
   gap: 2px;
 }
 
-.Sidebar__empty {
-  font-size: 14px;
-  color: var(--dim);
-}
-
 .Sidebar .FileInput {
-  margin-top: 16px;
+  margin-top: 8px;
 }
 
 /* Main content */

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -21,7 +21,13 @@ import {
   Severity,
   Workflow,
 } from './utils/types';
-import { AUDIO_CLASSIFIER_URL, CHUNK_MS, AUDIO_ANALYSIS_CHUNK_SIZE, TEXT_CLASSIFIER_URL } from './utils/variables';
+import {
+  AUDIO_CLASSIFIER_URL,
+  CHUNK_MS,
+  AUDIO_ANALYSIS_CHUNK_SIZE,
+  TEXT_CLASSIFIER_URL,
+  TAG_THRESHOLD,
+} from './utils/variables';
 import { useLocalStorage } from './utils/useLocalStorage';
 import { ReactComponent as MicIcon } from './assets/mic.svg';
 import { ReactComponent as Empty } from './assets/empty.svg';
@@ -196,12 +202,15 @@ function App() {
         const rawClassifications = json['classifications'] as Classification[];
 
         const updatedClassifications = rawClassifications.map((c) => {
-          const workflow = workflows.find((w) => w.eventLabel === c.label && w.threshold <= c.score);
-          if (workflow) {
+          if (workflows.length) {
+            const hasWorkflow = workflows.find((w) => w.eventLabel === c.label && w.threshold <= c.score);
             const severity = textEvents.find((t) => t.label === c.label)?.severity;
-            return { ...c, ...(severity && { severity }) };
+            return hasWorkflow ? { ...c, ...(severity && { severity }) } : c;
+          } else {
+            const hasClassification = textEvents.find((t) => t.label === c.label && TAG_THRESHOLD <= c.score);
+            const severity = textEvents.find((t) => t.label === c.label)?.severity;
+            return hasClassification ? { ...c, ...(severity && { severity }) } : c;
           }
-          return c;
         });
 
         const updatedWorkflows = updatedClassifications

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -46,9 +46,6 @@ const defaultTextEvents: Classification[] = [
   { label: 'a derogatory comment based on faith', severity: 'negative', score: 0 },
   { label: 'a derogatory comment based on sexual orientation', severity: 'negative', score: 0 },
 ];
-const defaultWorkflows: Workflow[] = [
-  { count: 2, eventLabel: defaultTextEvents[0].label, threshold: 0.7, action: 'warn', sum: 0 },
-];
 
 function App() {
   const { appId, client, segment, clientState, listening, start, stop } = useSpeechContext();
@@ -60,7 +57,7 @@ function App() {
     { name: 'DJ Gecko Cumbia Music', src: sample2 },
     { name: 'Buying Walmart’s Display PS5', src: sample3 },
   ]);
-  const [workflows, setWorkflows] = useLocalStorage<Workflow[]>('workflowRules', defaultWorkflows);
+  const [workflows, setWorkflows] = useLocalStorage<Workflow[]>('workflowRules', []);
   const [audioSource, setAudioSource] = useState<string>();
   const [detectionBuffer, setDetectionBuffer] = useState<Float32Array>(new Float32Array());
   const [micBuffer, setMicBuffer] = useState<Float32Array[]>([]);

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -443,79 +443,81 @@ function App() {
     <>
       <div className="App">
         <div className="Sidebar">
-          <div className="Sidebar__title">
-            <h4>Text events</h4>
-            <Popover
-              title="Add text event"
-              close={closePopover}
-            >
-              <EventForm
-                onSubmit={handleAddEvent}
-                textEvents={textEvents}
-              />
-            </Popover>
-          </div>
-          {textEvents.length ? (
-            <div className="Sidebar__grid">
-              {textEvents.map(({ label, severity }, i) => (
-                <Tag
-                  key={`event-${label}-${i}`}
-                  onRemove={() => handleRemoveEvent(i)}
-                  severity={severity}
-                  size="normal"
-                  label={label}
-                />
-              ))}
-            </div>
-          ) : (
-            <span className="Sidebar__empty">No text events</span>
-          )}
-          <div className="Sidebar__title">
-            <h4>Workflows</h4>
-            <Popover
-              title="Add workflow"
-              close={closePopover}
-            >
-              <WorkflowForm
-                textEvents={textEvents}
-                onSubmit={handleAddWorkflow}
-              />
-            </Popover>
-          </div>
-          {workflows.length ? (
-            <div className="Sidebar__list">
-              {workflows?.map(({ count, eventLabel, threshold, action }, i) => (
-                <WorkflowItem
-                  key={`rule-${eventLabel}-${action}-${i}`}
-                  count={count}
-                  label={eventLabel}
-                  threshold={threshold}
-                  action={action}
-                  onDelete={() => handleRemoveWorkflow(i)}
-                />
-              ))}
-            </div>
-          ) : (
-            <span className="Sidebar__empty">No workflows</span>
-          )}
-          <div className="Sidebar__title">
-            <h4>Audio files</h4>
-          </div>
-          <div className="Sidebar__list">
-            {files.map(({ name }, i) => (
-              <AudioFile
-                key={name}
-                isSelected={selectedFileId === i}
-                onClick={() => handleSelectFile(i)}
+          <div className="Sidebar__section">
+            <div className="Sidebar__title">
+              <h4>Text events</h4>
+              <Popover
+                title="Add text event"
+                close={closePopover}
               >
-                {name}
-              </AudioFile>
-            ))}
+                <EventForm
+                  onSubmit={handleAddEvent}
+                  textEvents={textEvents}
+                />
+              </Popover>
+            </div>
+            {textEvents.length ? (
+              <div className="Sidebar__grid">
+                {textEvents.map(({ label, severity }, i) => (
+                  <Tag
+                    key={`event-${label}-${i}`}
+                    onRemove={() => handleRemoveEvent(i)}
+                    severity={severity}
+                    size="normal"
+                    label={label}
+                  />
+                ))}
+              </div>
+            ) : null}
           </div>
-          <FileInput
-            acceptMimes="audio/wav,audio/mpeg,audio/m4a,audio/mp4"
-            onFileSelected={handleFileAdd}
-          />
+          <div className="Sidebar__section">
+            <div className="Sidebar__title">
+              <h4>Workflows</h4>
+              <Popover
+                title="Add workflow"
+                close={closePopover}
+              >
+                <WorkflowForm
+                  textEvents={textEvents}
+                  onSubmit={handleAddWorkflow}
+                />
+              </Popover>
+            </div>
+            {workflows.length ? (
+              <div className="Sidebar__list">
+                {workflows?.map(({ count, eventLabel, threshold, action }, i) => (
+                  <WorkflowItem
+                    key={`rule-${eventLabel}-${action}-${i}`}
+                    count={count}
+                    label={eventLabel}
+                    threshold={threshold}
+                    action={action}
+                    onDelete={() => handleRemoveWorkflow(i)}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <div className="Sidebar__section">
+            <div className="Sidebar__title">
+              <h4>Audio files</h4>
+            </div>
+            <div className="Sidebar__list">
+              {files.map(({ name }, i) => (
+                <AudioFile
+                  key={name}
+                  isSelected={selectedFileId === i}
+                  onClick={() => handleSelectFile(i)}
+                >
+                  {name}
+                </AudioFile>
+              ))}
+            </div>
+            <FileInput
+              acceptMimes="audio/wav,audio/mpeg,audio/m4a,audio/mp4"
+              onFileSelected={handleFileAdd}
+            />
+          </div>
         </div>
         <div
           className="Main"

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -153,6 +153,11 @@ function App() {
     if (detectionBuffer.length >= AUDIO_ANALYSIS_CHUNK_SIZE) {
       const chunks = chunk(detectionBuffer, AUDIO_ANALYSIS_CHUNK_SIZE);
       chunks.map((c, i) => classifyBuffer(i, c));
+      return;
+    }
+    if (detectionBuffer.length > 0 && detectionBuffer.length < AUDIO_ANALYSIS_CHUNK_SIZE) {
+      classifyBuffer(0, detectionBuffer);
+      return;
     }
   }, [detectionBuffer, classifyBuffer]);
 

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -150,12 +150,14 @@ function App() {
       return result;
     };
 
+    if (!detectionBuffer.length) return;
     if (detectionBuffer.length >= AUDIO_ANALYSIS_CHUNK_SIZE) {
+      console.log('eka');
       const chunks = chunk(detectionBuffer, AUDIO_ANALYSIS_CHUNK_SIZE);
       chunks.map((c, i) => classifyBuffer(i, c));
       return;
     }
-    if (detectionBuffer.length > 0 && detectionBuffer.length < AUDIO_ANALYSIS_CHUNK_SIZE) {
+    if (detectionBuffer.length < AUDIO_ANALYSIS_CHUNK_SIZE) {
       classifyBuffer(0, detectionBuffer);
       return;
     }

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -155,7 +155,6 @@ function App() {
 
     if (!detectionBuffer.length) return;
     if (detectionBuffer.length >= AUDIO_ANALYSIS_CHUNK_SIZE) {
-      console.log('eka');
       const chunks = chunk(detectionBuffer, AUDIO_ANALYSIS_CHUNK_SIZE);
       chunks.map((c, i) => classifyBuffer(i, c));
       return;

--- a/demos/analyzer/src/components/Popover.css
+++ b/demos/analyzer/src/components/Popover.css
@@ -46,7 +46,7 @@
   border-radius: 8px;
   background: var(--day);
   width: 400px;
-  padding: 24px 28px;
+  padding: 24px 32px 32px;
   position: absolute;
   top: 40%;
   left: 50%;
@@ -59,4 +59,11 @@
 .Popover__content h2 {
   margin-top: 0;
   font-size: 20px;
+}
+
+.Popover__close {
+  cursor: pointer;
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }

--- a/demos/analyzer/src/components/Popover.tsx
+++ b/demos/analyzer/src/components/Popover.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import clsx from 'clsx';
 import { useTransition } from 'transition-hook';
 import { ReactComponent as AddIcon } from '../assets/add.svg';
+import { ReactComponent as CloseIcon } from '../assets/close.svg';
 import './Popover.css';
 
 interface Props {
@@ -39,9 +40,13 @@ export const Popover: React.FC<Props> = ({ title, children, close }) => {
           <div className={classes}>
             <div
               className="Popover__bg"
-              onClick={() => setVisible(!isVisible)}
+              onClick={() => setVisible(false)}
             />
             <div className="Popover__content">
+              <CloseIcon
+                className="Popover__close"
+                onClick={() => setVisible(false)}
+              />
               <h2>{title}</h2>
               {children}
             </div>

--- a/demos/analyzer/src/components/Waveform.css
+++ b/demos/analyzer/src/components/Waveform.css
@@ -8,8 +8,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  height: 20px;
+  flex-wrap: wrap;
+  gap: 0 8px;
+  min-height: 20px;
 }
 
 .Waveform__data span {

--- a/demos/analyzer/src/components/Waveform.css
+++ b/demos/analyzer/src/components/Waveform.css
@@ -89,6 +89,14 @@
   background-color: var(--accent-25) !important;
 }
 
+.Waveform .wavesurfer-region[data-id^='highlight'] {
+  background-color: rgb(235, 85, 71, 0.25) !important;
+}
+
+.Waveform .wavesurfer-region[data-id^='highlight']:hover {
+  background-color: rgb(235, 85, 71, 0.375) !important;
+}
+
 .Waveform .wavesurfer-handle {
   width: 0.5px !important;
   background-color: var(--dim) !important;

--- a/demos/analyzer/src/components/Waveform.css
+++ b/demos/analyzer/src/components/Waveform.css
@@ -10,11 +10,11 @@
   justify-content: center;
   flex-wrap: wrap;
   gap: 0 8px;
-  min-height: 20px;
+  min-height: 22px;
+  color: var(--dim);
 }
 
 .Waveform__data span {
-  color: var(--dim);
   font-size: 14px;
   line-height: 20px;
   text-align: center;

--- a/demos/analyzer/src/components/Waveform.css
+++ b/demos/analyzer/src/components/Waveform.css
@@ -1,6 +1,6 @@
 .Waveform {
   width: 100%;
-  padding: 12px 24px 16px;
+  padding: 12px 20px 16px;
   overflow: hidden;
 }
 

--- a/demos/analyzer/src/components/Waveform.tsx
+++ b/demos/analyzer/src/components/Waveform.tsx
@@ -203,7 +203,7 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
             name="volume"
             min="0.01"
             max="1"
-            step=".025"
+            step="0.01"
             onChange={onVolumeChange}
             defaultValue={volume}
           />

--- a/demos/analyzer/src/components/Waveform.tsx
+++ b/demos/analyzer/src/components/Waveform.tsx
@@ -106,9 +106,17 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
     if (wavesurfer.current && regionData?.length) {
       wavesurfer.current.regions.clear();
       regionData.sort((a, b) => a.index - b.index);
-      regionData.forEach(({ start, end, classifications }) => {
+      regionData.forEach(({ start, end, classifications }, idx) => {
         const obj = Object.assign({}, classifications);
-        const region = { start, end, data: { ...obj }, drag: false };
+        const negativeTones = ['shouting', 'angry'];
+        const isNegativeTone = classifications.some((t) => t.type === 'toneofvoice' && negativeTones.includes(t.label));
+        const region = {
+          ...(isNegativeTone && { id: `highlight-${idx}` }),
+          start,
+          end,
+          data: { ...obj },
+          drag: false,
+        };
         wavesurfer.current?.regions.add(region);
       });
     }

--- a/demos/analyzer/src/components/Waveform.tsx
+++ b/demos/analyzer/src/components/Waveform.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useSpeechContext } from '@speechly/react-client';
 import WaveSurfer from 'wavesurfer.js';
 import RegionsPlugin, { Region } from 'wavesurfer.js/src/plugin/regions';
 import TimelinePlugin from 'wavesurfer.js/src/plugin/timeline';
@@ -46,6 +47,7 @@ const formWaveSurferOptions = (containerRef: any, timelineRef: any) => ({
 });
 
 export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, onRegionClick, onUpdate }) => {
+  const { listening } = useSpeechContext();
   const waveformRef: { current: HTMLDivElement | null } = useRef(null);
   const timelineRef: { current: HTMLDivElement | null } = useRef(null);
   const wavesurfer: { current: WaveSurfer | null } = useRef(null);
@@ -107,6 +109,7 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
       setSelectedData(undefined);
       setIsPlaying(false);
     }
+    if (wavesurfer.current && regionData?.length && !listening) {
       wavesurfer.current.regions.clear();
       regionData.sort((a, b) => a.index - b.index);
       regionData.forEach(({ start, end, classifications }, idx) => {
@@ -124,7 +127,7 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
         wavesurfer.current?.regions.add(region);
       });
     }
-  }, [url, regionData]);
+  }, [url, regionData, listening]);
 
   const handlePlayPause = () => {
     wavesurfer.current?.playPause();

--- a/demos/analyzer/src/components/Waveform.tsx
+++ b/demos/analyzer/src/components/Waveform.tsx
@@ -4,6 +4,7 @@ import RegionsPlugin, { Region } from 'wavesurfer.js/src/plugin/regions';
 import TimelinePlugin from 'wavesurfer.js/src/plugin/timeline';
 import { Tag } from './Tag';
 import { AudioRegionLabels, Classification } from '../utils/types';
+import { NEGATIVE_TONES } from '../utils/variables';
 import { ReactComponent as Play } from '../assets/play.svg';
 import { ReactComponent as Pause } from '../assets/pause.svg';
 import { ReactComponent as VolumeUp } from '../assets/volume.svg';
@@ -108,8 +109,9 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
       regionData.sort((a, b) => a.index - b.index);
       regionData.forEach(({ start, end, classifications }, idx) => {
         const obj = Object.assign({}, classifications);
-        const negativeTones = ['shouting', 'angry'];
-        const isNegativeTone = classifications.some((t) => t.type === 'toneofvoice' && negativeTones.includes(t.label));
+        const isNegativeTone = classifications.some(
+          (t) => t.type === 'toneofvoice' && NEGATIVE_TONES.includes(t.label)
+        );
         const region = {
           ...(isNegativeTone && { id: `highlight-${idx}` }),
           start,
@@ -148,6 +150,8 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
                 key={`tone-${label}-${i}`}
                 label={label.toLowerCase()}
                 score={score}
+                severity={NEGATIVE_TONES.includes(label) ? 'negative' : undefined}
+                size={NEGATIVE_TONES.includes(label) ? 'small' : undefined}
               />
             ))}
           </>

--- a/demos/analyzer/src/components/Waveform.tsx
+++ b/demos/analyzer/src/components/Waveform.tsx
@@ -103,8 +103,10 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
   }, [url, peaks]);
 
   useEffect(() => {
-    if (wavesurfer.current && regionData?.length === 0) setSelectedData(undefined);
-    if (wavesurfer.current && regionData?.length) {
+    if (wavesurfer.current && regionData?.length === 0) {
+      setSelectedData(undefined);
+      setIsPlaying(false);
+    }
       wavesurfer.current.regions.clear();
       regionData.sort((a, b) => a.index - b.index);
       regionData.forEach(({ start, end, classifications }, idx) => {

--- a/demos/analyzer/src/components/Waveform.tsx
+++ b/demos/analyzer/src/components/Waveform.tsx
@@ -102,6 +102,7 @@ export const Waveform: React.FC<Props> = ({ url, peaks, regionData, children, on
   }, [url, peaks]);
 
   useEffect(() => {
+    if (wavesurfer.current && regionData?.length === 0) setSelectedData(undefined);
     if (wavesurfer.current && regionData?.length) {
       wavesurfer.current.regions.clear();
       regionData.sort((a, b) => a.index - b.index);

--- a/demos/analyzer/src/components/WorkflowForm.tsx
+++ b/demos/analyzer/src/components/WorkflowForm.tsx
@@ -43,6 +43,7 @@ export const WorkflowForm: React.FC<Props> = ({ textEvents, onSubmit }) => {
         <select
           name="event"
           style={{ textTransform: 'none' }}
+          disabled={textEvents.length === 0}
         >
           {textEvents.map(({ label }) => (
             <option

--- a/demos/analyzer/src/utils/variables.ts
+++ b/demos/analyzer/src/utils/variables.ts
@@ -4,3 +4,4 @@ export const TEXT_CLASSIFIER_URL = 'https://api.speechly.com/text-classifier-api
 export const AUDIO_CLASSIFIER_URL = 'https://api.speechly.com/text-classifier-api/classifyAudio';
 export const MAX_TAGS = 8;
 export const TAG_THRESHOLD = 0.75;
+export const NEGATIVE_TONES = ['shouting', 'angry'];

--- a/demos/analyzer/src/utils/variables.ts
+++ b/demos/analyzer/src/utils/variables.ts
@@ -3,3 +3,4 @@ export const AUDIO_ANALYSIS_CHUNK_SIZE = 16 * CHUNK_MS;
 export const TEXT_CLASSIFIER_URL = 'https://api.speechly.com/text-classifier-api/classify';
 export const AUDIO_CLASSIFIER_URL = 'https://api.speechly.com/text-classifier-api/classifyAudio';
 export const MAX_TAGS = 8;
+export const TAG_THRESHOLD = 0.75;


### PR DESCRIPTION
### What

- UI improvements for displaying the audio events data
  - Wrap tags when wider than container
  - Clear tags when selecting another file / using microphone
- Classify audio clips less than 2 seconds (current chunk threshold)
- Highlight text labels with score over 75% if no workflows are defined, when workflows are defined use the specified workflow threshold
- No workflows by default
- Highlight region where tone of voice is either `shouting` or `angry`

### Why

Improve demo experience and support short audio clips. Keep in mind that we set the threshold for a reason, so very short audio clips might be somewhat inaccurate. Still, this is better than doing nothing.

