### PR TITLE
Refactor microphone implementation in demos

### DIFF
--- a/demos/analyzer/package.json
+++ b/demos/analyzer/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "homepage": "/analyzer/",
   "dependencies": {
-    "@speechly/browser-client": "^2.6.5",
     "@speechly/demo-navigation": "^0.2.14",
     "@speechly/react-client": "^2.2.4",
     "clsx": "^1.2.1",

--- a/demos/analyzer/src/App.css
+++ b/demos/analyzer/src/App.css
@@ -54,7 +54,7 @@ body {
 
 .Sidebar__title h4 {
   margin: 0;
-  font-weight: 500;
+  font-weight: 700;
   line-height: 24px;
 }
 
@@ -135,7 +135,7 @@ body {
   border-radius: 100px;
   background-color: var(--accent);
   font-size: 15px;
-  font-weight: 500;
+  font-weight: 700;
   color: var(--day);
   padding: 12px;
   transition: var(--ease);

--- a/demos/analyzer/src/App.css
+++ b/demos/analyzer/src/App.css
@@ -112,12 +112,17 @@ body {
 }
 
 .EmptyState__title {
-  font-size: 24px;
-  font-weight: 500;
+  font-size: 22px;
+  font-weight: 700;
 }
 
 .EmptyState__description {
   line-height: 1.5;
+}
+
+.EmptyState__description a {
+  color: inherit;
+  text-underline-offset: 2px;
 }
 
 .Microphone {

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -510,7 +510,7 @@ function App() {
         <div className="Main" ref={mainRef}>
           {!speechSegments.length && showEmptyState && (
             <div className="EmptyState">
-              <Empty className="EmptyState__icon" />
+              <Empty className="EmptyState__icon" width={180} />
               <h2 className="EmptyState__title">Speech and audio analysis</h2>
               <p className="EmptyState__description">
                 Use one of our sample files, upload your own audio or use the microphone.

--- a/demos/analyzer/src/App.tsx
+++ b/demos/analyzer/src/App.tsx
@@ -160,8 +160,9 @@ function App() {
       const name = `Recording at ${timeStr}`;
       setFiles((current) => [...current, { name, src }]);
       setRecData(undefined);
+      setSelectedFileId(files.length);
     }
-  }, [recData]);
+  }, [recData, files.length]);
 
   useEffect(() => {
     if (clientState <= 2) {

--- a/demos/analyzer/src/components/Dialog.css
+++ b/demos/analyzer/src/components/Dialog.css
@@ -3,7 +3,7 @@
   align-items: center;
   background-color: var(--dawn);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 700;
   padding: 4px 6px 4px 10px;
   line-height: 20px;
   border-radius: 4px;

--- a/demos/analyzer/src/components/Form.css
+++ b/demos/analyzer/src/components/Form.css
@@ -62,7 +62,7 @@
   cursor: pointer;
   flex-grow: 1;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 700;
   line-height: 20px;
   padding: 8px;
   transition: var(--ease);

--- a/demos/analyzer/src/components/SegmentItem.css
+++ b/demos/analyzer/src/components/SegmentItem.css
@@ -33,7 +33,7 @@
   padding: 4px 8px;
   border-radius: 3px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 700;
   line-height: 20px;
   text-transform: uppercase;
   letter-spacing: 0.01em;

--- a/demos/analyzer/src/index.css
+++ b/demos/analyzer/src/index.css
@@ -49,6 +49,9 @@ body {
   color: var(--night);
   background-color: var(--day);
   position: relative;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 button:focus,

--- a/demos/transcription/package.json
+++ b/demos/transcription/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "homepage": "/transcription/",
   "dependencies": {
-    "@speechly/browser-client": "^2.6.5",
     "@speechly/demo-navigation": "^0.2.14",
     "@speechly/react-client": "^2.2.4",
     "clsx": "^1.2.1",

--- a/demos/transcription/src/App.css
+++ b/demos/transcription/src/App.css
@@ -116,8 +116,8 @@ body {
 }
 
 .EmptyState__title {
-  font-size: 24px;
-  font-weight: 500;
+  font-size: 22px;
+  font-weight: 700;
 }
 
 .EmptyState__description {
@@ -126,6 +126,7 @@ body {
 
 .EmptyState__description a {
   color: inherit;
+  text-underline-offset: 2px;
 }
 
 .EmptyState__description a:hover {

--- a/demos/transcription/src/App.css
+++ b/demos/transcription/src/App.css
@@ -37,7 +37,7 @@ body {
 }
 
 .Sidebar__title {
-  font-weight: 500;
+  font-weight: 700;
   margin: 24px 24px 4px;
 }
 
@@ -182,7 +182,7 @@ body {
   border-radius: 100px;
   background-color: var(--accent);
   font-size: 15px;
-  font-weight: 500;
+  font-weight: 700;
   color: var(--day);
   padding: 12px;
   transition: var(--ease);

--- a/demos/transcription/src/App.tsx
+++ b/demos/transcription/src/App.tsx
@@ -67,8 +67,9 @@ function App() {
       const name = `Recording ${timeStr}`;
       setFiles((current) => [...current, { name, src }]);
       setRecData(undefined);
+      setSelectedFileId(files.length);
     }
-  }, [recData]);
+  }, [recData, files.length]);
 
   useEffect(() => {
     const scrollToSegmentsEnd = () =>

--- a/demos/transcription/src/App.tsx
+++ b/demos/transcription/src/App.tsx
@@ -226,7 +226,7 @@ function App() {
         <div className="Main" ref={mainRef}>
           {!speechSegments.length && showEmptyState && (
             <div className="EmptyState">
-              <Empty className="EmptyState__icon" />
+              <Empty className="EmptyState__icon" width={180} />
               <h2 className="EmptyState__title">Transcribe speech and audio files</h2>
               <p className="EmptyState__description">
                 This demo uses our off-the-shelf{' '}

--- a/demos/transcription/src/index.css
+++ b/demos/transcription/src/index.css
@@ -48,6 +48,9 @@ body {
   text-rendering: optimizeLegibility;
   color: var(--night);
   background-color: var(--day);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 button:focus,


### PR DESCRIPTION
### What

- Refactor microphone implementation in **transcription** and **analyzer** demos. Use `microphone` object available through react-client instead of the `ourMic` implementation.
- Set latest recording as "selected" item.
- Update styles, mainly empty state and font smoothing/weights.

### Why

React-client version `2.2.4` fixed the undefined microphone object, making it possible to use it instead of our custom microphone implementation.

