### PR TITLE
Add tooltip for flagged labels

### DIFF
--- a/demos/moderation/src/components/SegmentItem.tsx
+++ b/demos/moderation/src/components/SegmentItem.tsx
@@ -5,6 +5,7 @@ import { Tag } from './Tag';
 import { LabeledSpeechSegment } from '../utils/types';
 import { ReactComponent as Spinner } from '../assets/3-dots-fade-black-36.svg';
 import './SegmentItem.css';
+import { Tooltip } from './Tooltip';
 
 interface Props {
   segment: LabeledSpeechSegment;
@@ -37,7 +38,12 @@ export const SegmentItem: React.FC<Props> = ({ segment, currentTime }) => {
         <span>Abuse labels:</span>
         {abuseLabels === undefined && <Spinner width={16} height={16} fill="#7d8fa1" />}
         {abuseLabels?.map(({ label, score, flagged }) => (
-          <Tag key={label} label={label} score={score} isFlagged={flagged} />
+          <Tooltip
+            key={label}
+            title={flagged ? 'This label was flagged as abusive. Each label has its own threshold for flagging.' : ''}
+          >
+            <Tag label={label} score={score} isFlagged={flagged} />
+          </Tooltip>
         ))}
       </div>
     </div>

--- a/demos/moderation/src/components/Tooltip.css
+++ b/demos/moderation/src/components/Tooltip.css
@@ -1,0 +1,41 @@
+.Tooltip {
+  cursor: default;
+  position: relative;
+}
+
+.Tooltip__item {
+  position: absolute;
+  background: var(--night);
+  color: var(--day);
+  font-size: 12px;
+  line-height: 1.334;
+  padding: 8px 12px;
+  top: calc(100% + 4px);
+  width: 180px;
+  left: 50%;
+  margin-left: -90px;
+  border-radius: 3px;
+  opacity: 0;
+  pointer-events: none;
+  transition: var(--ease);
+  transform: translateY(-8px);
+  z-index: 100;
+}
+
+.Tooltip__item:before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 4px 4px 4px;
+  border-color: transparent transparent #333 transparent;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -4px;
+}
+
+.Tooltip:hover .Tooltip__item {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/demos/moderation/src/components/Tooltip.tsx
+++ b/demos/moderation/src/components/Tooltip.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import './Tooltip.css';
+
+interface Props {
+  title?: string;
+  children?: React.ReactNode;
+}
+
+export const Tooltip: React.FC<Props> = ({ children, title }) => {
+  return (
+    <div className="Tooltip">
+      {children}
+      {title && <div className="Tooltip__item">{title}</div>}
+    </div>
+  );
+};


### PR DESCRIPTION
An attempt to clarify the flagged labels to the user:

- Flagged labels have a hover tooltip that explains that the label in question was flagged and that each label has their own threshold for flagging.
- Non-flagged labels do not have a tooltip

![image](https://github.com/speechly/speechly/assets/2579244/df9f7a2b-b91b-498e-911a-31ca4a93b8a3)
